### PR TITLE
Introduce PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ software/generic/build
 assembly/*.zip
 *.d
 *.o
+.pio
 .vscode

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,34 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = software
+
+[env]
+lib_deps = 
+	fastled/FastLED@^3.4.0
+	google/googletest@^1.10.0
+	mikem/RadioHead@^1.113
+
+[env:node]
+platform = https://github.com/candykingdom/platform-candykingdomsam.git
+board = rfboard
+framework = arduino
+monitor_speed = 115200
+src_filter = +<*> -<*/test/*> -<arduino/devices> +<arduino/devices/node>
+
+[env:range_test]
+; TODO
+
+[env:remote]
+; TODO
+
+[env:trellis]
+; TODO

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,6 @@ src_dir = software
 [env]
 lib_deps = 
 	fastled/FastLED@^3.4.0
-	google/googletest@^1.10.0
 	mikem/RadioHead@^1.113
 
 [env:node]

--- a/software/arduino/FastLedManager.hpp
+++ b/software/arduino/FastLedManager.hpp
@@ -3,9 +3,9 @@
 
 #include <vector>
 
-#include "Effect.hpp"
-#include "LedManager.hpp"
-#include "Types.hpp"
+#include "../generic/Effect.hpp"
+#include "../generic/LedManager.hpp"
+#include "../generic/Types.hpp"
 
 class FastLedManager : public LedManager {
  public:

--- a/software/arduino/RadioHeadRadio.hpp
+++ b/software/arduino/RadioHeadRadio.hpp
@@ -3,7 +3,7 @@
 
 #include <RH_RF69.h>
 
-#include "Radio.hpp"
+#include "../generic/Radio.hpp"
 
 const int kMaxFifoSizePacketSize = 64;
 const int kRadioOverhead = 3;

--- a/software/arduino/node/node.cpp
+++ b/software/arduino/node/node.cpp
@@ -2,10 +2,10 @@
 // (which it shouldn't)
 #undef max
 #undef min
-#include <FastLedManager.hpp>
-#include <NetworkManager.hpp>
-#include <RadioHeadRadio.hpp>
-#include <RadioStateMachine.hpp>
+#include "../../generic/NetworkManager.hpp"
+#include "../../generic/RadioStateMachine.hpp"
+#include "../FastLedManager.hpp"
+#include "../RadioHeadRadio.hpp"
 
 const int kLedPin = 0;
 const int kNumLeds = 30;  // Bike


### PR DESCRIPTION
Note that this change is breaking and untested! (The best kind of
change) The Candykingdom rfboard definitions have not yet been ported so
are not available on PIO yet.

More changes to come to introduce more device types.