### PR TITLE
Add ControlEffect

### DIFF
--- a/software/generic/ControlEffect.cpp
+++ b/software/generic/ControlEffect.cpp
@@ -13,9 +13,9 @@ ControlEffect::ControlEffect(uint8_t numLeds, DeviceType deviceType)
 
 CRGB ControlEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
                               RadioPacket *setEffectPacket) {
-  uint8_t r = setEffectPacket->readRFromSetRgb();
-  uint8_t g = setEffectPacket->readGFromSetRgb();
-  uint8_t b = setEffectPacket->readBFromSetRgb();
+  uint8_t r = setEffectPacket->readRFromSetControl();
+  uint8_t g = setEffectPacket->readGFromSetControl();
+  uint8_t b = setEffectPacket->readBFromSetControl();
 
   return CRGB(r, g ,b);
 }

--- a/software/generic/ControlEffect.cpp
+++ b/software/generic/ControlEffect.cpp
@@ -1,0 +1,21 @@
+#include "ControlEffect.hpp"
+
+static inline uint8_t min(uint8_t a, uint8_t b) {
+  if (a < b) {
+    return a;
+  } else {
+    return b;
+  }
+}
+
+ControlEffect::ControlEffect(uint8_t numLeds, DeviceType deviceType)
+    : Effect(numLeds, deviceType) {}
+
+CRGB ControlEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
+                              RadioPacket *setEffectPacket) {
+  uint8_t r = setEffectPacket->readRFromSetRgb();
+  uint8_t g = setEffectPacket->readGFromSetRgb();
+  uint8_t b = setEffectPacket->readBFromSetRgb();
+
+  return CRGB(r, g ,b);
+}

--- a/software/generic/ControlEffect.cpp
+++ b/software/generic/ControlEffect.cpp
@@ -4,10 +4,6 @@ ControlEffect::ControlEffect(uint8_t numLeds, DeviceType deviceType)
     : Effect(numLeds, deviceType) {}
 
 CRGB ControlEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
-                              RadioPacket *setEffectPacket) {
-  uint8_t r = setEffectPacket->readRFromSetControl();
-  uint8_t g = setEffectPacket->readGFromSetControl();
-  uint8_t b = setEffectPacket->readBFromSetControl();
-
-  return CRGB(r, g ,b);
+                           RadioPacket *setEffectPacket) {
+  return setEffectPacket->readRgbFromSetControl();
 }

--- a/software/generic/ControlEffect.cpp
+++ b/software/generic/ControlEffect.cpp
@@ -1,13 +1,5 @@
 #include "ControlEffect.hpp"
 
-static inline uint8_t min(uint8_t a, uint8_t b) {
-  if (a < b) {
-    return a;
-  } else {
-    return b;
-  }
-}
-
 ControlEffect::ControlEffect(uint8_t numLeds, DeviceType deviceType)
     : Effect(numLeds, deviceType) {}
 

--- a/software/generic/ControlEffect.hpp
+++ b/software/generic/ControlEffect.hpp
@@ -1,0 +1,21 @@
+#ifndef __CONTROL_EFFECT_HPP__
+#define __CONTROL_EFFECT_HPP__
+
+#include "Effect.hpp"
+#include "Types.hpp"
+
+/** A generic effect that can be used by external controllers. */
+class ControlEffect : public Effect {
+ public:
+  ControlEffect(uint8_t numLeds, DeviceType deviceType);
+
+  /** Gets the value of a specific LED at a specific time. */
+  CRGB GetRGB(uint8_t ledIndex, uint32_t timeMs,
+              RadioPacket *setEffectPacket) override;
+
+  private:
+    uint8_t r = 0;
+    uint8_t g = 0;
+    uint8_t b = 0;
+};
+#endif

--- a/software/generic/ControlEffect.hpp
+++ b/software/generic/ControlEffect.hpp
@@ -13,9 +13,9 @@ class ControlEffect : public Effect {
   CRGB GetRGB(uint8_t ledIndex, uint32_t timeMs,
               RadioPacket *setEffectPacket) override;
 
-  private:
-    uint8_t r = 0;
-    uint8_t g = 0;
-    uint8_t b = 0;
+ private:
+  uint8_t r = 0;
+  uint8_t g = 0;
+  uint8_t b = 0;
 };
 #endif

--- a/software/generic/LedManager.cpp
+++ b/software/generic/LedManager.cpp
@@ -52,7 +52,7 @@ LedManager::LedManager(const uint8_t numLeds, DeviceType deviceType,
 }
 
 Effect *LedManager::GetCurrentEffect() {
-  RadioPacket* packet = radioState->GetSetEffect();
+  RadioPacket *packet = radioState->GetSetEffect();
   if (packet->type == SET_CONTROL) {
     return controlEffect;
   }

--- a/software/generic/LedManager.cpp
+++ b/software/generic/LedManager.cpp
@@ -45,11 +45,17 @@ LedManager::LedManager(const uint8_t numLeds, DeviceType deviceType,
   AddEffect(new DisplayColorPaletteEffect(numLeds, deviceType), 0);
   AddEffect(new DarkEffect(numLeds), 0);
 
+  controlEffect = new ControlEffect(numLeds, deviceType);
+
   radioState->SetNumEffects(GetNumEffects());
   radioState->SetNumPalettes(effects[0]->palettes.size());
 }
 
 Effect *LedManager::GetCurrentEffect() {
+  RadioPacket* packet = radioState->GetSetEffect();
+  if (packet->type == SET_CONTROL) {
+    return controlEffect;
+  }
   uint8_t effectIndex =
       radioState->GetSetEffect()->readEffectIndexFromSetEffect();
   return GetEffect(effectIndex);

--- a/software/generic/LedManager.hpp
+++ b/software/generic/LedManager.hpp
@@ -3,10 +3,10 @@
 
 #include <vector>
 
+#include "ControlEffect.hpp"
 #include "Effect.hpp"
 #include "Radio.hpp"
 #include "RadioStateMachine.hpp"
-#include "ControlEffect.hpp"
 #include "Types.hpp"
 
 class LedManager {
@@ -61,6 +61,6 @@ class LedManager {
 
   void AddEffect(Effect *Effect, uint8_t proportion);
 
-  ControlEffect* controlEffect;
+  ControlEffect *controlEffect;
 };
 #endif

--- a/software/generic/LedManager.hpp
+++ b/software/generic/LedManager.hpp
@@ -6,6 +6,7 @@
 #include "Effect.hpp"
 #include "Radio.hpp"
 #include "RadioStateMachine.hpp"
+#include "ControlEffect.hpp"
 #include "Types.hpp"
 
 class LedManager {
@@ -59,5 +60,7 @@ class LedManager {
   std::vector<uint8_t> uniqueEffectIndices;
 
   void AddEffect(Effect *Effect, uint8_t proportion);
+
+  ControlEffect* controlEffect;
 };
 #endif

--- a/software/generic/Radio.cpp
+++ b/software/generic/Radio.cpp
@@ -37,19 +37,17 @@ uint8_t RadioPacket::readDelayFromSetEffect() { return this->data[1]; }
 
 uint8_t RadioPacket::readPaletteIndexFromSetEffect() { return this->data[2]; }
 
-void RadioPacket::writeControl(uint8_t delay, uint8_t r, uint8_t g, uint8_t b) {
+void RadioPacket::writeControl(uint8_t delay, CRGB rgb) {
   this->type = SET_CONTROL;
   this->dataLength = 4;
   this->data[0] = delay;
-  this->data[1] = r;
-  this->data[2] = g;
-  this->data[3] = b;
+  this->data[1] = rgb.r;
+  this->data[2] = rgb.g;
+  this->data[3] = rgb.b;
 }
 
 uint8_t RadioPacket::readDelayFromSetControl() { return this->data[0]; }
 
-uint8_t RadioPacket::readRFromSetControl() { return this->data[1]; }
-
-uint8_t RadioPacket::readGFromSetControl() { return this->data[2]; }
-
-uint8_t RadioPacket::readBFromSetControl() { return this->data[3]; }
+CRGB RadioPacket::readRgbFromSetControl() {
+  return CRGB(this->data[1], this->data[2], this->data[3]);
+}

--- a/software/generic/Radio.cpp
+++ b/software/generic/Radio.cpp
@@ -36,3 +36,20 @@ uint8_t RadioPacket::readEffectIndexFromSetEffect() { return this->data[0]; }
 uint8_t RadioPacket::readDelayFromSetEffect() { return this->data[1]; }
 
 uint8_t RadioPacket::readPaletteIndexFromSetEffect() { return this->data[2]; }
+
+void RadioPacket::writeControl(uint8_t delay, uint8_t r, uint8_t g, uint8_t b) {
+  this->type = SET_CONTROL;
+  this->dataLength = 4;
+  this->data[0] = delay;
+  this->data[1] = r;
+  this->data[2] = g;
+  this->data[3] = b;
+}
+
+uint8_t RadioPacket::readDelayFromSetControl() { return this->data[0]; }
+
+uint8_t RadioPacket::readRFromSetControl() { return this->data[1]; }
+
+uint8_t RadioPacket::readGFromSetControl() { return this->data[2]; }
+
+uint8_t RadioPacket::readBFromSetControl() { return this->data[3]; }

--- a/software/generic/Radio.hpp
+++ b/software/generic/Radio.hpp
@@ -16,6 +16,9 @@ enum PacketType {
   // (e.g. the car remote) can also send this, and may include a flag for the
   // master to not change the pattern for a certain amount of time.
   SET_EFFECT,
+
+  // Used to set the exact RGB values that the device should display.
+  SET_CONTROL,
 };
 
 static const uint8_t PACKET_DATA_LENGTH = 58;
@@ -56,6 +59,12 @@ struct RadioPacket {
   uint8_t readEffectIndexFromSetEffect();
   uint8_t readDelayFromSetEffect();
   uint8_t readPaletteIndexFromSetEffect();
+
+  void writeControl(uint8_t delay, uint8_t r, uint8_t g, uint8_t b);
+  uint8_t readDelayFromSetControl();
+  uint8_t readRFromSetControl();
+  uint8_t readGFromSetControl();
+  uint8_t readBFromSetControl();
 };
 
 inline bool operator==(const RadioPacket& lhs, const RadioPacket& rhs) {

--- a/software/generic/Radio.hpp
+++ b/software/generic/Radio.hpp
@@ -60,11 +60,12 @@ struct RadioPacket {
   uint8_t readDelayFromSetEffect();
   uint8_t readPaletteIndexFromSetEffect();
 
-  void writeControl(uint8_t delay, uint8_t r, uint8_t g, uint8_t b);
+  // For SET_CONTROL
+  // delay: time for the master to not change the effect, in seconds
+  // rgb: the color to set the node to
+  void writeControl(uint8_t delay, CRGB rgb);
   uint8_t readDelayFromSetControl();
-  uint8_t readRFromSetControl();
-  uint8_t readGFromSetControl();
-  uint8_t readBFromSetControl();
+  CRGB readRgbFromSetControl();
 };
 
 inline bool operator==(const RadioPacket& lhs, const RadioPacket& rhs) {

--- a/software/generic/RadioStateMachine.cpp
+++ b/software/generic/RadioStateMachine.cpp
@@ -2,9 +2,9 @@
 
 #include <cstdio>
 
+#include "ControlEffect.hpp"
 #include "Debug.hpp"
 #include "Effect.hpp"
-#include "../generic/ControlEffect.hpp"
 
 //#define DEBUG
 
@@ -124,8 +124,7 @@ void RadioStateMachine::handleSlaveEvent(RadioEventData &data) {
                  kSlaveNoPacketTimeout + rand() % kSlaveNoPacketRandom);
         break;
 
-      case SET_EFFECT:
-      {
+      case SET_EFFECT: {
         uint8_t newEffectIndex = data.packet->readEffectIndexFromSetEffect();
         uint8_t newPaletteIndex = data.packet->readPaletteIndexFromSetEffect();
         if (effectIndex != this->effectIndex ||
@@ -172,13 +171,12 @@ void RadioStateMachine::handleMasterEvent(RadioEventData &data) {
         nextState = RadioState::Slave;
         break;
 
-      case SET_EFFECT:
-      {
+      case SET_EFFECT: {
         this->setEffectPacket = *data.packet;
         this->effectIndex = data.packet->readEffectIndexFromSetEffect();
-        uint32_t setEfectTime =
+        uint32_t setEffectTime =
             (uint32_t)(data.packet->readDelayFromSetEffect()) * 1000;
-        SetTimer(TimerChangeEffect, setEfectTime);
+        SetTimer(TimerChangeEffect, setEffectTime);
         break;
       }
 


### PR DESCRIPTION
This effect is not intended to be in the standard rotation but can be
used by external controllers to manually set the color of the entire
device.