### PR TITLE
Add a startup animation

### DIFF
--- a/software/arduino/FastLedManager.cpp
+++ b/software/arduino/FastLedManager.cpp
@@ -12,6 +12,20 @@ FastLedManager::FastLedManager(const DeviceDescription *device,
 
 void FastLedManager::SetGlobalColor(CRGB rgb) { FastLED.showColor(rgb); }
 
+void FastLedManager::PlayStartupAnimation() {
+  CRGB white = CRGB(128, 128, 128);
+  for (uint8_t i = 0; i < device->physical_leds * 2; ++i) {
+    uint8_t index = i;
+    if (i >= device->physical_leds) {
+      index = device->physical_leds - (i - device->physical_leds);
+    }
+    FastLED.clear();
+    SetLed(index, &white);
+    FastLED.show();
+    delay(500 / device->physical_leds);
+  }
+}
+
 void FastLedManager::SetLed(uint8_t ledIndex, CRGB *const rgb) {
   // The first LED is on-board, and should mirror the first LED of the strip.
   if (ledIndex == 0) {

--- a/software/arduino/FastLedManager.hpp
+++ b/software/arduino/FastLedManager.hpp
@@ -14,6 +14,8 @@ class FastLedManager : public LedManager {
 
   void SetGlobalColor(CRGB rgb);
 
+  void PlayStartupAnimation();
+
  protected:
   void SetLed(uint8_t ledIndex, CRGB *const rgb) override;
 

--- a/software/devices/node/node.cpp
+++ b/software/devices/node/node.cpp
@@ -40,10 +40,7 @@ void setup() {
   // NOTE: can check if we watchdog rebooted by checking REG_PM_RCAUSE
   // See https://github.com/gjt211/SAMD21-Reset-Cause
 
-  // TODO: remove blink
-  ledManager->SetGlobalColor(CRGB(CRGB::White));
-  delay(20);
-  ledManager->SetGlobalColor(CRGB(CRGB::Black));
+  ledManager->PlayStartupAnimation();
 
   // Set up the watchdog timer: this will reset the processor if it hasn't
   // 'fed' the watchdog in ~100ms.


### PR DESCRIPTION
This 1s animation lights up every light on the device. It makes it easy
to see if the board is configured to use the device it is plugged into.