### PR TITLE
Redefine DeviceDescription in terms of flags

### DIFF
--- a/software/arduino/FastLedManager.cpp
+++ b/software/arduino/FastLedManager.cpp
@@ -4,8 +4,8 @@ FastLedManager::FastLedManager(const DeviceDescription *device,
                                RadioStateMachine *radioState)
     : LedManager(device, radioState) {
   // The first LED is on-board, and should mirror the first LED of the strip.
-  leds = new CRGB[device->physical_leds + 1];
-  FastLED.addLeds<NEOPIXEL, WS2812_PIN>(leds, device->physical_leds + 1)
+  leds = new CRGB[device->led_count + 1];
+  FastLED.addLeds<NEOPIXEL, WS2812_PIN>(leds, device->led_count + 1)
       .setCorrection(TypicalLEDStrip);
   FastLED.showColor(CRGB(0, 0, 0));
 }
@@ -14,15 +14,15 @@ void FastLedManager::SetGlobalColor(CRGB rgb) { FastLED.showColor(rgb); }
 
 void FastLedManager::PlayStartupAnimation() {
   CRGB white = CRGB(128, 128, 128);
-  for (uint8_t i = 0; i < device->physical_leds * 2; ++i) {
+  for (uint8_t i = 0; i < device->led_count * 2; ++i) {
     uint8_t index = i;
-    if (i >= device->physical_leds) {
-      index = device->physical_leds - (i - device->physical_leds);
+    if (i >= device->led_count) {
+      index = device->led_count - (i - device->led_count);
     }
     FastLED.clear();
     SetLed(index, &white);
     FastLED.show();
-    delay(500 / device->physical_leds);
+    delay(500 / device->led_count);
   }
 }
 

--- a/software/devices/node/node.cpp
+++ b/software/devices/node/node.cpp
@@ -10,11 +10,11 @@
 
 const int kLedPin = 0;
 
-const DeviceDescription *const bike = new DeviceDescription(30, Bright);
-const DeviceDescription *const scarf = new DeviceDescription(46, 0);
-const DeviceDescription *const lantern = new DeviceDescription(5, Tiny);
+const DeviceDescription *const bike = new DeviceDescription(30, {Bright});
+const DeviceDescription *const scarf = new DeviceDescription(46, {});
+const DeviceDescription *const lantern = new DeviceDescription(5, {Tiny});
 const DeviceDescription *const puck =
-    new DeviceDescription(12, Tiny | Circular);
+    new DeviceDescription(12, {Tiny, Circular});
 
 const DeviceDescription *const device = scarf;
 

--- a/software/devices/node/node.cpp
+++ b/software/devices/node/node.cpp
@@ -39,8 +39,6 @@ void setup() {
 
   ledManager->PlayStartupAnimation();
 
-  Serial.println(device->ToString());
-
   // Set up the watchdog timer: this will reset the processor if it hasn't
   // 'fed' the watchdog in ~100ms.
   // Inspired by

--- a/software/devices/node/node.cpp
+++ b/software/devices/node/node.cpp
@@ -10,16 +10,13 @@
 
 const int kLedPin = 0;
 
-const DeviceDescription *const bike =
-    new LinearDescription(30, DeviceType::Bike);
-const DeviceDescription *const scarf =
-    new LinearDescription(46, DeviceType::Wearable);
-const DeviceDescription *const lantern =
-    new LinearDescription(5, DeviceType::Wearable);
+const DeviceDescription *const bike = new DeviceDescription(30, Bright);
+const DeviceDescription *const scarf = new DeviceDescription(46, 0);
+const DeviceDescription *const lantern = new DeviceDescription(5, Tiny);
 const DeviceDescription *const puck =
-    new LinearDescription(12, DeviceType::Wearable);
+    new DeviceDescription(12, Tiny | Circular);
 
-const DeviceDescription *const device = puck;
+const DeviceDescription *const device = scarf;
 
 RadioHeadRadio *radio;
 NetworkManager *nm;
@@ -41,6 +38,8 @@ void setup() {
   // See https://github.com/gjt211/SAMD21-Reset-Cause
 
   ledManager->PlayStartupAnimation();
+
+  Serial.println(device->ToString());
 
   // Set up the watchdog timer: this will reset the processor if it hasn't
   // 'fed' the watchdog in ~100ms.

--- a/software/generic/ColorCycleEffect.cpp
+++ b/software/generic/ColorCycleEffect.cpp
@@ -14,18 +14,15 @@ CRGB ColorCycleEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   if (palette.Size() < 2) {
     // Solid color palette
     CHSV color = palette.GetColor(0);
-    switch (device->type) {
-      case DeviceType::Wearable:
-        color.v = ((uint16_t)cubicwave8(timeMs / 16)) * 2 / 3;
-        break;
-      case DeviceType::Bike:
-        color.v = ((uint16_t)cubicwave8(timeMs / 16));
-        break;
+    if (device->FlagEnabled(Bright)) {
+      color.v = ((uint16_t)cubicwave8(timeMs / 16));
+    } else {
+      color.v = ((uint16_t)cubicwave8(timeMs / 16)) * 2 / 3;
     }
     return color;
   } else {
     CHSV color = palette.GetGradient((timeMs / 16) << 8);
-    if (device->type == DeviceType::Wearable) {
+    if (!device->FlagEnabled(Bright)) {
       color.v /= 2;
     }
     return color;

--- a/software/generic/DeviceDescription.cpp
+++ b/software/generic/DeviceDescription.cpp
@@ -1,13 +1,44 @@
 #include "DeviceDescription.hpp"
 
-DeviceDescription::DeviceDescription(DeviceType type, uint8_t physical_leds,
-                                     uint8_t virtual_leds)
-    : type(type), physical_leds(physical_leds), virtual_leds(virtual_leds) {}
+DeviceDescription::DeviceDescription(uint8_t led_count, uint8_t flags)
+    : led_count(led_count), flags(flags) {}
 
-LinearDescription::LinearDescription(uint8_t physical_leds,
-                                     DeviceType device_type)
-    : DeviceDescription(type, physical_leds, physical_leds) {}
+bool DeviceDescription::FlagEnabled(DeviceFlag flag) const {
+  return (flags & (int)flag) == (int)flag;
+}
 
-uint8_t LinearDescription::PhysicalToVirtual(uint8_t p_index) const {
-  return p_index;
+const String DeviceDescription::ToString() const {
+  String string_builder;
+
+  string_builder.concat("Firefly device with ");
+  string_builder.concat(led_count);
+  string_builder.concat(" LEDs");
+
+  if (flags != 0) {
+    string_builder.concat("\nFlags:\n");
+
+    for (uint8_t i = 1; i < 8; ++i) {
+      uint8_t flag = 1 << i;
+
+      if (FlagEnabled((DeviceFlag)flag)) {
+        switch (flag) {
+          case (1 << 0):
+            string_builder.concat("Tiny\n");
+            break;
+          case (1 << 1):
+            string_builder.concat("Bright\n");
+            break;
+          case (1 << 2):
+            string_builder.concat("Circular\n");
+            break;
+          default:
+            string_builder.concat("Unrecognized flag: ");
+            string_builder.concat(flag);
+            string_builder.concat("\n");
+        }
+      }
+    }
+  }
+
+  return string_builder;
 }

--- a/software/generic/DeviceDescription.cpp
+++ b/software/generic/DeviceDescription.cpp
@@ -6,39 +6,3 @@ DeviceDescription::DeviceDescription(uint8_t led_count, uint8_t flags)
 bool DeviceDescription::FlagEnabled(DeviceFlag flag) const {
   return (flags & (int)flag) == (int)flag;
 }
-
-const String DeviceDescription::ToString() const {
-  String string_builder;
-
-  string_builder.concat("Firefly device with ");
-  string_builder.concat(led_count);
-  string_builder.concat(" LEDs");
-
-  if (flags != 0) {
-    string_builder.concat("\nFlags:\n");
-
-    for (uint8_t i = 1; i < 8; ++i) {
-      uint8_t flag = 1 << i;
-
-      if (FlagEnabled((DeviceFlag)flag)) {
-        switch (flag) {
-          case (1 << 0):
-            string_builder.concat("Tiny\n");
-            break;
-          case (1 << 1):
-            string_builder.concat("Bright\n");
-            break;
-          case (1 << 2):
-            string_builder.concat("Circular\n");
-            break;
-          default:
-            string_builder.concat("Unrecognized flag: ");
-            string_builder.concat(flag);
-            string_builder.concat("\n");
-        }
-      }
-    }
-  }
-
-  return string_builder;
-}

--- a/software/generic/DeviceDescription.cpp
+++ b/software/generic/DeviceDescription.cpp
@@ -1,7 +1,13 @@
 #include "DeviceDescription.hpp"
 
-DeviceDescription::DeviceDescription(uint8_t led_count, uint8_t flags)
-    : led_count(led_count), flags(flags) {}
+#include <functional>
+#include <numeric>
+
+DeviceDescription::DeviceDescription(uint8_t led_count,
+                                     std::list<DeviceFlag> flag_list)
+    : led_count(led_count),
+      flags(std::accumulate(flag_list.begin(), flag_list.end(), 0,
+                            std::bit_or<int>())) {}
 
 bool DeviceDescription::FlagEnabled(DeviceFlag flag) const {
   return (flags & (int)flag) == (int)flag;

--- a/software/generic/DeviceDescription.hpp
+++ b/software/generic/DeviceDescription.hpp
@@ -2,6 +2,7 @@
 #define __DEVICE_DESCRIPTION_HPP__
 
 #include <Types.hpp>
+#include <list>
 
 enum DeviceFlag {
   Tiny = 1 << 0,
@@ -13,7 +14,7 @@ class DeviceDescription {
  public:
   const uint8_t led_count;
 
-  DeviceDescription(uint8_t led_count, uint8_t flags);
+  DeviceDescription(uint8_t led_count, std::list<DeviceFlag> flags);
 
   bool FlagEnabled(DeviceFlag flag) const;
 

--- a/software/generic/DeviceDescription.hpp
+++ b/software/generic/DeviceDescription.hpp
@@ -2,7 +2,6 @@
 #define __DEVICE_DESCRIPTION_HPP__
 
 #include <Types.hpp>
-#include <string>
 
 enum DeviceFlag {
   Tiny = 1 << 0,
@@ -17,8 +16,6 @@ class DeviceDescription {
   DeviceDescription(uint8_t led_count, uint8_t flags);
 
   bool FlagEnabled(DeviceFlag flag) const;
-
-  const String ToString() const;
 
  private:
   const uint8_t flags;

--- a/software/generic/DeviceDescription.hpp
+++ b/software/generic/DeviceDescription.hpp
@@ -2,36 +2,25 @@
 #define __DEVICE_DESCRIPTION_HPP__
 
 #include <Types.hpp>
+#include <string>
 
-enum class DeviceType {
-  Wearable,
-  Bike,
+enum DeviceFlag {
+  Tiny = 1 << 0,
+  Bright = 1 << 1,
+  Circular = 1 << 2,
 };
 
 class DeviceDescription {
  public:
-  const DeviceType type;
-  const uint8_t physical_leds;
-  const uint8_t virtual_leds;
+  const uint8_t led_count;
 
-  virtual uint8_t PhysicalToVirtual(uint8_t p_index) const = 0;
+  DeviceDescription(uint8_t led_count, uint8_t flags);
 
- protected:
-  DeviceDescription(DeviceType type, uint8_t physical_leds,
-                    uint8_t virtual_leds);
-};
+  bool FlagEnabled(DeviceFlag flag) const;
 
-class CircularDescription : public DeviceDescription {
- public:
-  CircularDescription(uint8_t physical_leds, DeviceType device_type);
+  const String ToString() const;
 
-  uint8_t PhysicalToVirtual(uint8_t p_index) const;
-};
-
-class LinearDescription : public DeviceDescription {
- public:
-  LinearDescription(uint8_t physical_leds, DeviceType device_type);
-
-  uint8_t PhysicalToVirtual(uint8_t p_index) const;
+ private:
+  const uint8_t flags;
 };
 #endif  // __DEVICE_DESCRIPTION_HPP__

--- a/software/generic/DisplayColorPaletteEffect.cpp
+++ b/software/generic/DisplayColorPaletteEffect.cpp
@@ -9,7 +9,7 @@ CRGB DisplayColorPaletteEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   ColorPalette palette =
       palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
   CHSV color = palette.GetGradient((timeMs / 2) * 23);
-  if (device->type == DeviceType::Wearable) {
+  if (!device->FlagEnabled(Bright)) {
     color.v /= 2;
   }
   return color;

--- a/software/generic/LedManager.cpp
+++ b/software/generic/LedManager.cpp
@@ -77,10 +77,9 @@ Effect *LedManager::GetEffect(uint8_t index) {
 }
 
 void LedManager::RunEffect() {
-  for (uint8_t ledIndex = 0; ledIndex < device->physical_leds; ledIndex++) {
-    CRGB rgb = GetCurrentEffect()->GetRGB(device->PhysicalToVirtual(ledIndex),
-                                          radioState->GetNetworkMillis(),
-                                          radioState->GetSetEffect());
+  for (uint8_t ledIndex = 0; ledIndex < device->led_count; ledIndex++) {
+    CRGB rgb = GetCurrentEffect()->GetRGB(
+        ledIndex, radioState->GetNetworkMillis(), radioState->GetSetEffect());
     SetLed(ledIndex, &rgb);
   }
   WriteOutLeds();

--- a/software/generic/PoliceEffect.cpp
+++ b/software/generic/PoliceEffect.cpp
@@ -9,7 +9,7 @@ CRGB PoliceEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   const bool red_flash = (timeMs / redSpeed & 0b100) == 0;
   const bool blue_flash = (timeMs / blueSpeed & 0b100) == 0;
 
-  if (device->virtual_leds < lightWidth * 2) {
+  if (device->led_count < lightWidth * 2) {
     if (red_flash) {
       if (red_cycle) {
         return red;
@@ -38,13 +38,13 @@ CRGB PoliceEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   }
 
   if (blue_flash) {
-    if (ledIndex > device->virtual_leds - lightWidth / 2) {
+    if (ledIndex > device->led_count - lightWidth / 2) {
       if (blue_cycle) {
         return blue;
       } else {
         return off;
       }
-    } else if (ledIndex > device->virtual_leds - lightWidth) {
+    } else if (ledIndex > device->led_count - lightWidth) {
       if (blue_cycle) {
         return off;
       } else {

--- a/software/generic/RainbowEffect.cpp
+++ b/software/generic/RainbowEffect.cpp
@@ -1,14 +1,10 @@
 #include "RainbowEffect.hpp"
 
 RainbowEffect::RainbowEffect(const DeviceDescription *device) : Effect(device) {
-  switch (device->type) {
-    // Wearable gets reduced brightness, since we're lighting the whole strip.
-    case DeviceType::Wearable:
-      v = 128;
-      break;
-    case DeviceType::Bike:
-      v = 255;
-      break;
+  if (device->FlagEnabled(Bright)) {
+    v = 255;
+  } else {
+    v = 128;
   }
 }
 
@@ -20,23 +16,20 @@ CRGB RainbowEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   // brightness rather than the hue.
   if (palette.Size() < 2) {
     // Solid color palette
-    if (device->virtual_leds < 8) {
+    if (device->led_count < 8) {
       return palette.GetGradient((cubicwave8(timeMs / 16)) << 8);
     } else {
       CHSV color = palette.GetColor(0);
-      switch (device->type) {
-        case DeviceType::Wearable:
-          color.v = (cubicwave8(timeMs / 16 + ledIndex * 8) * (uint16_t)2) / 3;
-          break;
-        case DeviceType::Bike:
-          color.v = cubicwave8(timeMs / 16 + ledIndex * 8);
-          break;
+      if (device->FlagEnabled(Bright)) {
+        color.v = cubicwave8(timeMs / 16 + ledIndex * 8);
+      } else {
+        color.v = (cubicwave8(timeMs / 16 + ledIndex * 8) * (uint16_t)2) / 3;
       }
       return color;
     }
   } else {
     // Varying color palette
-    if (device->virtual_leds < 8) {
+    if (device->led_count < 8) {
       CHSV color = palette.GetGradient((timeMs / 16) << 8);
       color.v = v;
       return color;

--- a/software/generic/RorschachEffect.cpp
+++ b/software/generic/RorschachEffect.cpp
@@ -17,7 +17,7 @@ CRGB RorschachEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   const ColorPalette palette = palettes[paletteIndex];
 
   // LEDs at the center of the strip have a lower position.
-  const uint16_t led_pos = -abs(ledIndex - (device->virtual_leds >> 1));
+  const uint16_t led_pos = -abs(ledIndex - (device->led_count >> 1));
 
   timeMs += offset;
   uint16_t noise =
@@ -36,7 +36,7 @@ CRGB RorschachEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
     return color;
   } else {
     CHSV color = palette.GetGradient(noise << 8, false);
-    if (device->type == DeviceType::Wearable) {
+    if (!device->FlagEnabled(Bright)) {
       color.v /= 2;
     }
     return color;

--- a/software/generic/SimpleBlinkEffect.cpp
+++ b/software/generic/SimpleBlinkEffect.cpp
@@ -11,7 +11,7 @@ CRGB SimpleBlinkEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
     ColorPalette palette =
         palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
     CHSV color = palette.GetGradient((timeMs / 4) * 23);
-    if (device->type == DeviceType::Wearable) {
+    if (!device->FlagEnabled(Bright)) {
       color.v /= 2;
     }
     return color;

--- a/software/generic/SparkEffect.cpp
+++ b/software/generic/SparkEffect.cpp
@@ -7,21 +7,21 @@ CRGB SparkEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   const uint8_t pulse_size = brightnesses.size();
   const uint8_t paletteIndex = setEffectPacket->readPaletteIndexFromSetEffect();
   ColorPalette palette = palettes[paletteIndex];
-  int16_t pos = ((timeMs * (device->virtual_leds + pulse_size)) / 3000) %
-                ((device->virtual_leds + pulse_size) * 2);
+  int16_t pos = ((timeMs * (device->led_count + pulse_size)) / 3000) %
+                ((device->led_count + pulse_size) * 2);
 
   bool reverse = false;
-  if (pos > (device->virtual_leds + pulse_size)) {
+  if (pos > (device->led_count + pulse_size)) {
     reverse = true;
-    pos = (device->virtual_leds + pulse_size) -
-          (pos - (device->virtual_leds + pulse_size));
+    pos = (device->led_count + pulse_size) -
+          (pos - (device->led_count + pulse_size));
   }
   int16_t relative_pos = pos - ledIndex;
   CHSV hsv = palette.GetGradient((timeMs / 24 + relative_pos * 14) << 8);
 
   if (relative_pos < 0) {
     hsv.v = 0;
-  } else if (relative_pos < (device->virtual_leds + pulse_size)) {
+  } else if (relative_pos < (device->led_count + pulse_size)) {
     if (relative_pos < pulse_size) {
       if (reverse) {
         hsv.v = brightnesses[pulse_size - relative_pos - 1];

--- a/software/generic/StopLightEffect.cpp
+++ b/software/generic/StopLightEffect.cpp
@@ -5,15 +5,15 @@ StopLightEffect::StopLightEffect(const DeviceDescription *device)
 
 CRGB StopLightEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
                              RadioPacket *setEffectPacket) {
-  const uint16_t led_pos = abs((device->virtual_leds >> 1) - ledIndex) << 8;
-  const uint16_t segment = device->virtual_leds << (8 - 3);
+  const uint16_t led_pos = abs((device->led_count >> 1) - ledIndex) << 8;
+  const uint16_t segment = device->led_count << (8 - 3);
   timeMs = timeMs >> 11;
 
   const bool is_red = (timeMs & 0b100) == 0 && (timeMs & 0b11) > 0;
   const bool is_amber = (timeMs & 0b100) == 0 && (timeMs & 0b11) == 0;
   const bool is_green = (timeMs & 0b100);
 
-  if (device->virtual_leds < 16) {
+  if (device->led_count < 16) {
     if (is_red) {
       return red;
     } else if (is_amber) {

--- a/software/generic/SwingingLights.cpp
+++ b/software/generic/SwingingLights.cpp
@@ -21,7 +21,7 @@ CRGB SwingingLights::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   // This effect looks bad on less than 10 LEDs. Instead of creating another
   // effect we can just make the LEDs flash when a light pulse hits the end of a
   // "long" strip which looks pretty cool.
-  uint8_t numLeds = device->virtual_leds;  // < 10 ? 50 : device->virtual_leds;
+  uint8_t numLeds = device->led_count;  // < 10 ? 50 : device->led_count;
 
   // Map [0, period) to [0, MAX_UINT16)
   const fract16 angle = (timeMs % period) * MAX_UINT16 / period;

--- a/software/generic/test/DeviceDescriptionTest.cpp
+++ b/software/generic/test/DeviceDescriptionTest.cpp
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 
 TEST(DeviceDescription, usesFlagsCorrectly) {
-  DeviceDescription dd = DeviceDescription(10, Bright | Tiny);
+  DeviceDescription dd = DeviceDescription(10, {Bright, Tiny});
 
   EXPECT_EQ(dd.led_count, 10);
 

--- a/software/generic/test/DeviceDescriptionTest.cpp
+++ b/software/generic/test/DeviceDescriptionTest.cpp
@@ -1,0 +1,13 @@
+#include "../DeviceDescription.hpp"
+#include "../LedManager.hpp"
+#include "gtest/gtest.h"
+
+TEST(DeviceDescription, usesFlagsCorrectly) {
+  DeviceDescription dd = DeviceDescription(10, Bright | Tiny);
+
+  EXPECT_EQ(dd.led_count, 10);
+
+  EXPECT_TRUE(dd.FlagEnabled(Bright));
+  EXPECT_TRUE(dd.FlagEnabled(Tiny));
+  EXPECT_FALSE(dd.FlagEnabled(Circular));
+}

--- a/software/generic/test/EffectsTest.cpp
+++ b/software/generic/test/EffectsTest.cpp
@@ -34,17 +34,17 @@ void runEffectsTest(DeviceDescription *device, uint32_t maxTime) {
 }
 
 TEST(Effects, oneLed) {
-  DeviceDescription device = DeviceDescription(1, 0);
+  DeviceDescription device = DeviceDescription(1, {});
   runEffectsTest(&device, 60 * 1000);
 }
 
 TEST(Effects, hundredLeds) {
-  DeviceDescription device = DeviceDescription(100, 0);
+  DeviceDescription device = DeviceDescription(100, {});
   runEffectsTest(&device, 60 * 1000);
 }
 
 TEST(Effects, allLedValues) {
-  DeviceDescription device = DeviceDescription(1, 0);
+  DeviceDescription device = DeviceDescription(1, {});
   for (uint16_t numLeds = 0; numLeds < 256; numLeds++) {
     runEffectsTest(&device, 5 * 1000);
   }

--- a/software/generic/test/EffectsTest.cpp
+++ b/software/generic/test/EffectsTest.cpp
@@ -34,17 +34,17 @@ void runEffectsTest(DeviceDescription *device, uint32_t maxTime) {
 }
 
 TEST(Effects, oneLed) {
-  LinearDescription device = LinearDescription(1, DeviceType::Wearable);
+  DeviceDescription device = DeviceDescription(1, 0);
   runEffectsTest(&device, 60 * 1000);
 }
 
 TEST(Effects, hundredLeds) {
-  LinearDescription device = LinearDescription(1, DeviceType::Wearable);
+  DeviceDescription device = DeviceDescription(100, 0);
   runEffectsTest(&device, 60 * 1000);
 }
 
 TEST(Effects, allLedValues) {
-  LinearDescription device = LinearDescription(1, DeviceType::Wearable);
+  DeviceDescription device = DeviceDescription(1, 0);
   for (uint16_t numLeds = 0; numLeds < 256; numLeds++) {
     runEffectsTest(&device, 5 * 1000);
   }

--- a/software/generic/test/FakeLedManager.cpp
+++ b/software/generic/test/FakeLedManager.cpp
@@ -5,17 +5,17 @@
 FakeLedManager::FakeLedManager(const DeviceDescription *device,
                                RadioStateMachine *stateMachine)
     : LedManager(device, stateMachine) {
-  leds = new CRGB[device->physical_leds];
+  leds = new CRGB[device->led_count];
 }
 
 void FakeLedManager::SetGlobalColor(CRGB rgb) {
-  for (uint8_t i = 0; i < device->physical_leds; i++) {
+  for (uint8_t i = 0; i < device->led_count; i++) {
     leds[i] = rgb;
   }
 }
 
 CRGB FakeLedManager::GetLed(uint8_t ledIndex) {
-  assert(ledIndex < device->physical_leds);
+  assert(ledIndex < device->led_count);
   return leds[ledIndex];
 }
 
@@ -30,7 +30,7 @@ void FakeLedManager::PublicAddEffect(Effect *effect, uint8_t proportion) {
 }
 
 void FakeLedManager::SetLed(uint8_t ledIndex, CRGB *const rgb) {
-  assert(ledIndex < device->physical_leds);
+  assert(ledIndex < device->led_count);
   leds[ledIndex] = *rgb;
 }
 

--- a/software/generic/test/FakeNetwork.hpp
+++ b/software/generic/test/FakeNetwork.hpp
@@ -39,7 +39,7 @@ class FakeNetwork {
   int packetLoss = 0;
   FakeRadio radios[kNumNodes];
   RadioPacket *packet = nullptr;
-  const LinearDescription device = LinearDescription(5, DeviceType::Wearable);
+  const DeviceDescription device = DeviceDescription(5, 0);
 };
 
 #endif

--- a/software/generic/test/FakeNetwork.hpp
+++ b/software/generic/test/FakeNetwork.hpp
@@ -39,7 +39,7 @@ class FakeNetwork {
   int packetLoss = 0;
   FakeRadio radios[kNumNodes];
   RadioPacket *packet = nullptr;
-  const DeviceDescription device = DeviceDescription(5, 0);
+  const DeviceDescription device = DeviceDescription(5, {});
 };
 
 #endif

--- a/software/generic/test/LedManagerTest.cpp
+++ b/software/generic/test/LedManagerTest.cpp
@@ -8,7 +8,7 @@
 #include "gtest/gtest.h"
 
 TEST(LedManager, hasNonRandomEffects) {
-  DeviceDescription device = DeviceDescription(1, 0);
+  DeviceDescription device = DeviceDescription(1, {});
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *stateMachine = new RadioStateMachine(networkManager);
@@ -42,7 +42,7 @@ TEST(LedManager, hasNonRandomEffects) {
 }
 
 TEST(LedManager, effectIndexIsInRange) {
-  DeviceDescription device = DeviceDescription(1, 0);
+  DeviceDescription device = DeviceDescription(1, {});
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *stateMachine = new RadioStateMachine(networkManager);

--- a/software/generic/test/LedManagerTest.cpp
+++ b/software/generic/test/LedManagerTest.cpp
@@ -8,7 +8,7 @@
 #include "gtest/gtest.h"
 
 TEST(LedManager, hasNonRandomEffects) {
-  LinearDescription device = LinearDescription(1, DeviceType::Wearable);
+  DeviceDescription device = DeviceDescription(1, 0);
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *stateMachine = new RadioStateMachine(networkManager);
@@ -42,7 +42,7 @@ TEST(LedManager, hasNonRandomEffects) {
 }
 
 TEST(LedManager, effectIndexIsInRange) {
-  LinearDescription device = LinearDescription(1, DeviceType::Wearable);
+  DeviceDescription device = DeviceDescription(1, 0);
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *stateMachine = new RadioStateMachine(networkManager);


### PR DESCRIPTION
This allows us to branch on semantic flags as well as print out the
device description on startup.