### PR TITLE
Add polar interpolation of Perlin noise

### DIFF
--- a/software/generic/FireEffect.cpp
+++ b/software/generic/FireEffect.cpp
@@ -1,6 +1,6 @@
 #include "FireEffect.hpp"
 
-// #include "Math.hpp"
+#include "Math.hpp"
 #include "Perlin.hpp"
 
 FireEffect::FireEffect(const DeviceDescription *device) : Effect(device) {
@@ -17,7 +17,7 @@ CRGB FireEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
   if (device->FlagEnabled(Circular)) {
     uint8_t angle;
     uint8_t radius;
-    // GetPosOnCircle(device->led_count, ledIndex, &angle, &radius);
+    GetPosOnCircle(device->led_count, ledIndex, &angle, &radius);
 
     // Create 2 octave Perlin noise by averaging multiple samples.
     noise = (perlinNoisePolar(timeMs / 8, 0, angle, radius) / 4 * 3) +

--- a/software/generic/FireEffect.cpp
+++ b/software/generic/FireEffect.cpp
@@ -1,5 +1,6 @@
 #include "FireEffect.hpp"
 
+// #include "Math.hpp"
 #include "Perlin.hpp"
 
 FireEffect::FireEffect(const DeviceDescription *device) : Effect(device) {
@@ -12,10 +13,20 @@ FireEffect::FireEffect(const DeviceDescription *device) : Effect(device) {
 CRGB FireEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
                         RadioPacket *setEffectPacket) {
   timeMs += offset;
-  // Create 2 octave Perlin noise by averaging multiple samples.
-  uint8_t noise =
-      (perlinNoise(ledIndex * 20, timeMs / 8) / 4 * 3) +
-      (perlinNoise(ledIndex * 10 + 1234, timeMs / 2 + 1234567) / 4 * 1);
+  uint8_t noise;
+  if (device->FlagEnabled(Circular)) {
+    uint8_t angle;
+    uint8_t radius;
+    // GetPosOnCircle(device->led_count, ledIndex, &angle, &radius);
+
+    // Create 2 octave Perlin noise by averaging multiple samples.
+    noise = (perlinNoisePolar(timeMs / 8, 0, angle, radius) / 4 * 3) +
+            (perlinNoisePolar(timeMs / 2 + 1234567, 0, angle, radius) / 4 * 1);
+  } else {
+    // Create 2 octave Perlin noise by averaging multiple samples.
+    noise = (perlinNoise(ledIndex * 20, timeMs / 8) / 4 * 3) +
+            (perlinNoise(ledIndex * 10 + 1234, timeMs / 2 + 1234567) / 4 * 1);
+  }
 
   return palette.GetGradient(noise << 8, false);
 }

--- a/software/generic/Math.cpp
+++ b/software/generic/Math.cpp
@@ -1,0 +1,9 @@
+#include "Math.hpp"
+
+void GetPosOnCircle(uint8_t led_count, uint8_t led_index, uint8_t *angle,
+                    uint8_t *radius) {
+  uint32_t tau = 6283;
+  uint32_t circum = led_count * 32;
+  *angle = led_index * 255 / led_count;
+  *radius = (circum * 1000) / tau;
+}

--- a/software/generic/Math.hpp
+++ b/software/generic/Math.hpp
@@ -14,11 +14,6 @@
  * Perlin noise functoins.
  */
 void GetPosOnCircle(uint8_t led_count, uint8_t led_index, uint8_t *angle,
-                    uint8_t *radius) {
-  uint32_t tau = 6283;
-  uint32_t circum = led_count * 32;
-  *angle = led_index * 255 / led_count;
-  *radius = (circum * 1000) / tau;
-}
+                    uint8_t *radius);
 
 #endif  // __MATH_HPP__

--- a/software/generic/Math.hpp
+++ b/software/generic/Math.hpp
@@ -1,0 +1,24 @@
+#ifndef __MATH_HPP__
+#define __MATH_HPP__
+
+#include <Types.hpp>
+
+/**
+ * @brief Gets the polar vector for evenly spaced points on a circle.
+ *
+ * @param led_count How many total points are on the circle.
+ * @param led_index Which point we are referring to.
+ * @param angle Returns the angle of the point on the circle from [0, 255].
+ * @param radius Returns the magnitude of the vector, AKA the radius of the
+ * circle. This is in an arbitrary unit that is designed to look good with the
+ * Perlin noise functoins.
+ */
+void GetPosOnCircle(uint8_t led_count, uint8_t led_index, uint8_t *angle,
+                    uint8_t *radius) {
+  uint32_t tau = 6283;
+  uint32_t circum = led_count * 32;
+  *angle = led_index * 255 / led_count;
+  *radius = (circum * 1000) / tau;
+}
+
+#endif  // __MATH_HPP__

--- a/software/generic/Perlin.hpp
+++ b/software/generic/Perlin.hpp
@@ -62,4 +62,14 @@ inline uint8_t perlinNoise(uint32_t x, uint32_t y) {
   return val;
 }
 
+// Generates 2D perlin noise in the range [0, 256) given an initial catesian
+// coordinate and a polar offset.
+inline uint8_t perlinNoisePolar(uint32_t x, uint32_t y, uint8_t angle,
+                                uint8_t magnitude) {
+  int32_t x_offset = ((int16_t)cos8(angle) - 128) * magnitude / 128;
+  int32_t y_offset = ((int16_t)sin8(angle) - 128) * magnitude / 127;
+
+  return perlinNoise(x + x_offset, y + y_offset);
+}
+
 #endif

--- a/software/generic/Perlin.hpp
+++ b/software/generic/Perlin.hpp
@@ -64,7 +64,7 @@ inline uint8_t perlinNoise(uint32_t x, uint32_t y) {
 
 /**
  * Generates 2D perlin noise in the range [0, 256) given an initial cartesian
-// coordinate and a polar offset.
+ * coordinate and a polar offset.
  */
 inline uint8_t perlinNoisePolar(uint32_t x, uint32_t y, uint8_t angle,
                                 uint8_t magnitude) {

--- a/software/generic/Perlin.hpp
+++ b/software/generic/Perlin.hpp
@@ -62,8 +62,10 @@ inline uint8_t perlinNoise(uint32_t x, uint32_t y) {
   return val;
 }
 
-// Generates 2D perlin noise in the range [0, 256) given an initial catesian
+/**
+ * Generates 2D perlin noise in the range [0, 256) given an initial cartesian
 // coordinate and a polar offset.
+ */
 inline uint8_t perlinNoisePolar(uint32_t x, uint32_t y, uint8_t angle,
                                 uint8_t magnitude) {
   int32_t x_offset = ((int16_t)cos8(angle) - 128) * magnitude / 128;

--- a/software/generic/test/MathTest.cpp
+++ b/software/generic/test/MathTest.cpp
@@ -1,0 +1,57 @@
+#include "../Math.hpp"
+#include "gtest/gtest.h"
+
+TEST(Math, shouldGetCardinalCordinates) {
+  uint8_t angle;
+  uint8_t radius;
+
+  // By 4s
+  GetPosOnCircle(4, 0, &angle, &radius);
+  ASSERT_EQ(angle, 0);
+  ASSERT_EQ(radius, 20);
+
+  GetPosOnCircle(4, 1, &angle, &radius);
+  ASSERT_EQ(angle, 63);
+  ASSERT_EQ(radius, 20);
+
+  GetPosOnCircle(4, 2, &angle, &radius);
+  ASSERT_EQ(angle, 127);
+  ASSERT_EQ(radius, 20);
+
+  GetPosOnCircle(4, 3, &angle, &radius);
+  ASSERT_EQ(angle, 191);
+  ASSERT_EQ(radius, 20);
+
+  // By 8s
+  GetPosOnCircle(8, 0, &angle, &radius);
+  ASSERT_EQ(angle, 0);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 1, &angle, &radius);
+  ASSERT_EQ(angle, 31);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 2, &angle, &radius);
+  ASSERT_EQ(angle, 63);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 3, &angle, &radius);
+  ASSERT_EQ(angle, 95);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 4, &angle, &radius);
+  ASSERT_EQ(angle, 127);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 5, &angle, &radius);
+  ASSERT_EQ(angle, 159);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 6, &angle, &radius);
+  ASSERT_EQ(angle, 191);
+  ASSERT_EQ(radius, 40);
+
+  GetPosOnCircle(8, 7, &angle, &radius);
+  ASSERT_EQ(angle, 223);
+  ASSERT_EQ(radius, 40);
+}

--- a/software/generic/test/PerlinTest.cpp
+++ b/software/generic/test/PerlinTest.cpp
@@ -10,8 +10,7 @@ TEST(Perlin, shouldProduceContiguousNoise) {
 
     uint16_t first = perlinNoise(x, y);
     uint16_t second = perlinNoise(x + 1, y + 1);
-    ASSERT_TRUE(abs(first - second) <= tolerance)
-        << "Tested " << x << ", " << y;
+    ASSERT_LE(abs(first - second), tolerance) << "Tested " << x << ", " << y;
   }
 }
 
@@ -20,7 +19,7 @@ TEST(Perlin, shouldWrapAround) {
     uint32_t y = random();
     uint16_t start = perlinNoise(0, y);
     uint16_t end = perlinNoise(4294967295, y);
-    ASSERT_TRUE(abs(start - end) <= tolerance)
+    ASSERT_LE(abs(start - end), tolerance)
         << "Tested " << 4294967295 << ", " << y;
   }
 
@@ -28,7 +27,49 @@ TEST(Perlin, shouldWrapAround) {
     uint32_t x = random();
     uint16_t start = perlinNoise(x, 0);
     uint16_t end = perlinNoise(x, 4294967295);
-    ASSERT_TRUE(abs(start - end) <= tolerance)
+    ASSERT_LE(abs(start - end), tolerance)
         << "Tested " << x << ", " << 4294967295;
+  }
+}
+
+TEST(Perlin, shouldProduceContiguousNoiseLinearly) {
+  for (uint8_t i = 0; i < 255; ++i) {
+    uint32_t x = random();
+    uint32_t y = random();
+    uint32_t angle = random();
+
+    uint16_t first = perlinNoisePolar(x, y, angle, i);
+    uint16_t second = perlinNoisePolar(x, y, angle, i + 1);
+    ASSERT_LE(abs(first - second), tolerance);
+  }
+}
+
+TEST(Perlin, shouldProduceContiguousNoiseRadially) {
+  for (uint8_t i = 0; i < 255; ++i) {
+    uint32_t x = random();
+    uint32_t y = random();
+    uint8_t magnitude = random();
+    // The distance between points radially can get very large, make sure the
+    // magnitude isn't too high!
+    magnitude /= 2;
+
+    uint16_t first = perlinNoisePolar(x, y, i, magnitude);
+    uint16_t second = perlinNoisePolar(x, y, i + 1, magnitude);
+    ASSERT_LE(abs(first - second), tolerance);
+  }
+}
+
+TEST(Perlin, shouldWrapAroundPolar) {
+  for (uint8_t i = 0; i < 255; ++i) {
+    uint32_t x = random();
+    uint32_t y = random();
+    uint8_t magnitude = random();
+    // The distance between points radially can get very large, make sure the
+    // magnitude isn't too high!
+    magnitude /= 2;
+
+    uint16_t first = perlinNoisePolar(x, y, 0, magnitude);
+    uint16_t second = perlinNoisePolar(x, y, 255, magnitude);
+    ASSERT_LE(abs(first - second), tolerance);
   }
 }


### PR DESCRIPTION
This allows us to render Perlin noise across circular devices correctly.