### PR TITLE
Update Contrast Bump for circular devices

### DIFF
--- a/software/generic/ContrastBumpsEffect.cpp
+++ b/software/generic/ContrastBumpsEffect.cpp
@@ -7,8 +7,15 @@ CRGB ContrastBumpsEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
                                  RadioPacket *setEffectPacket) {
   const uint8_t paletteIndex = setEffectPacket->readPaletteIndexFromSetEffect();
   ColorPalette palette = palettes[paletteIndex];
+  
+  uint8_t offset; 
+  if (device->FlagEnabled(Circular)) {
+    offset = (uint16_t)ledIndex * 255 / device->led_count;
+  } else {
+    offset = ledIndex * 24;
+  }
 
-  uint8_t sin = GetThresholdSin(-(timeMs / 16 + ledIndex * 24) << 8, 0);
+  uint8_t sin = GetThresholdSin(-(timeMs / 16 + offset) << 8, 0);
   uint16_t colorIndex = timeMs * 16;
   if (sin == 0) {
     CHSV color = palette.GetGradient(colorIndex);

--- a/software/generic/ContrastBumpsEffect.cpp
+++ b/software/generic/ContrastBumpsEffect.cpp
@@ -7,8 +7,8 @@ CRGB ContrastBumpsEffect::GetRGB(uint8_t ledIndex, uint32_t timeMs,
                                  RadioPacket *setEffectPacket) {
   const uint8_t paletteIndex = setEffectPacket->readPaletteIndexFromSetEffect();
   ColorPalette palette = palettes[paletteIndex];
-  
-  uint8_t offset; 
+
+  uint8_t offset;
   if (device->FlagEnabled(Circular)) {
     offset = (uint16_t)ledIndex * 255 / device->led_count;
   } else {


### PR DESCRIPTION
This splits the device into 2 even halves and runs the effect on each.