### PR TITLE
Store DeviceDescription in memory

### DIFF
--- a/lib/arduino/FastLedManager.cpp
+++ b/lib/arduino/FastLedManager.cpp
@@ -14,15 +14,21 @@ FastLedManager::FastLedManager(const DeviceDescription *device,
 
 void FastLedManager::SetGlobalColor(CRGB rgb) { FastLED.showColor(rgb); }
 
-void FastLedManager::PlayStartupAnimation() {
-  CRGB white = CRGB(128, 128, 128);
+void FastLedManager::PlayStartupAnimation(bool error) {
+  CRGB color;
+  if (error) {
+    color = CRGB(128, 0, 0);
+  } else {
+    color = CRGB(128, 128, 128);
+  }
+
   for (uint8_t i = 0; i < device->led_count * 2; ++i) {
     uint8_t index = i;
     if (i >= device->led_count) {
       index = device->led_count - (i - device->led_count);
     }
     FastLED.clear();
-    SetLed(index, &white);
+    SetLed(index, &color);
     FastLED.show();
     delay(500 / device->led_count);
   }

--- a/lib/arduino/FastLedManager.hpp
+++ b/lib/arduino/FastLedManager.hpp
@@ -15,7 +15,7 @@ class FastLedManager : public LedManager {
 
   void SetGlobalColor(CRGB rgb);
 
-  void PlayStartupAnimation();
+  void PlayStartupAnimation(bool error);
 
  protected:
   void SetLed(uint8_t led_index, CRGB *const rgb) override;

--- a/lib/device/DeviceDescription.cpp
+++ b/lib/device/DeviceDescription.cpp
@@ -5,7 +5,8 @@
 
 DeviceDescription::DeviceDescription(uint8_t led_count,
                                      std::list<DeviceFlag> flag_list)
-    : led_count(led_count),
+    : description_version(DEVICE_DESCRIPTION_VERSION),
+      led_count(led_count),
       flags(std::accumulate(flag_list.begin(), flag_list.end(), 0,
                             std::bit_or<int>())) {}
 

--- a/lib/device/DeviceDescription.hpp
+++ b/lib/device/DeviceDescription.hpp
@@ -5,6 +5,14 @@
 
 #include "../types/Types.hpp"
 
+/**
+ * @brief The version number of the current DeviceDescription schema.
+ *
+ * This is intended to help with deserializing and need only be updated when
+ * breaking changes to the DeviceDescription object are made.
+ */
+const uint16_t DEVICE_DESCRIPTION_VERSION = 1;
+
 enum DeviceFlag {
   Tiny = 1 << 0,
   Bright = 1 << 1,
@@ -14,6 +22,8 @@ enum DeviceFlag {
 
 class DeviceDescription {
  public:
+  const uint16_t description_version;
+
   const uint8_t led_count;
 
   DeviceDescription(uint8_t led_count, std::list<DeviceFlag> flags);

--- a/lib/flash_storage/FlashStorage.cpp
+++ b/lib/flash_storage/FlashStorage.cpp
@@ -1,0 +1,17 @@
+#include <FlashStorage_SAMD.h>
+
+#include "../storage/Storage.hpp"
+
+const int DD_LOCATION = 0x0;
+
+bool GetDeviceDescription(const DeviceDescription* const device) {
+  EEPROM.get(DD_LOCATION, device);
+
+  return device->description_version == DEVICE_DESCRIPTION_VERSION;
+}
+
+bool PutDeviceDescription(const DeviceDescription* device) {
+  EEPROM.put(DD_LOCATION, device);
+
+  return true;
+}

--- a/lib/storage/Storage.hpp
+++ b/lib/storage/Storage.hpp
@@ -1,0 +1,22 @@
+#ifndef __STORAGE_H__
+#define __STORAGE_H__
+
+#include "../device/DeviceDescription.hpp"
+
+/**
+ * @brief Retrieves the DeviceDescription from storage and returns a boolean if reading was successful.
+ * 
+ * @param device A pointer to write the DeviceDescription into.
+ * @return If retrieving the DeviceDescription was successful.
+ */
+bool GetDeviceDescription(const DeviceDescription* device);
+
+/**
+ * @brief Stores the DeviceDescription to storage and returns a boolean if reading was successful.
+ * 
+ * @param device A pointer to the DeviceDescription to store.
+ * @return If storing the DeviceDescription was successful.
+ */
+bool PutDeviceDescription(const DeviceDescription* device);
+
+#endif  // __STORAGE_H__

--- a/lib/storage/Storage.hpp
+++ b/lib/storage/Storage.hpp
@@ -4,16 +4,18 @@
 #include "../device/DeviceDescription.hpp"
 
 /**
- * @brief Retrieves the DeviceDescription from storage and returns a boolean if reading was successful.
- * 
+ * @brief Retrieves the DeviceDescription from storage and returns a boolean if
+ * reading was successful.
+ *
  * @param device A pointer to write the DeviceDescription into.
  * @return If retrieving the DeviceDescription was successful.
  */
 bool GetDeviceDescription(const DeviceDescription* device);
 
 /**
- * @brief Stores the DeviceDescription to storage and returns a boolean if reading was successful.
- * 
+ * @brief Stores the DeviceDescription to storage and returns a boolean if
+ * reading was successful.
+ *
  * @param device A pointer to the DeviceDescription to store.
  * @return If storing the DeviceDescription was successful.
  */

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,15 +19,25 @@ framework = arduino
 monitor_speed = 115200
 build_src_filter = +<lib> +<software/devices/node>
 platform_packages = 
-; Choose the correct package for your OS:
 	tool-bossac-candykingdom @ https://candykingdom.github.io/firefly-v2-board/tools/bossac_linux.tar.bz2
-;	tool-bossac-candykingdom @ https://candykingdom.github.io/firefly-v2-board/tools/bossac_osx.tar.bz2
-;	tool-bossac-candykingdom @ https://candykingdom.github.io/firefly-v2-board/tools/bossac_windows.tar.bz2
-lib_deps =
+lib_deps = 
 	arduino
 	https://github.com/candykingdom/FastLED.git
 	mikem/RadioHead@^1.113
-  SPI
+	SPI
+	khoih-prog/FlashStorage_SAMD@^1.3.2
+
+[env:node_writer]
+platform = https://github.com/candykingdom/platform-candykingdomsam.git
+board = rfboard
+framework = arduino
+monitor_speed = 115200
+build_src_filter = +<lib/storage> +<lib/flash_storage> +<software/devices/node_writer>
+platform_packages = 
+	tool-bossac-candykingdom @ https://candykingdom.github.io/firefly-v2-board/tools/bossac_linux.tar.bz2
+lib_deps = 
+	arduino
+	khoih-prog/FlashStorage_SAMD@^1.3.2
 
 [env:dmx]
 platform = espressif32
@@ -39,21 +49,9 @@ build_flags =
 	-D RADIO_SS=32
 	-D RADIO_DIO=14
 	-D WS2812_PIN=15
-	; -D MISO=19
-	; -D MOSI=18
-	; -D SCK=5
-lib_deps =
+lib_deps = 
 	SPI
 	arduino
 	fastled/FastLED@^3.4.0
 	mikem/RadioHead@^1.113
 	sparkfun/SparkFun DMX Shield Library@^1.0.5
-
-; [env:range_test]
-; TODO
-
-; [env:remote]
-; TODO
-
-; [env:trellis]
-; TODO

--- a/software/devices/node_writer/node_writer.cpp
+++ b/software/devices/node_writer/node_writer.cpp
@@ -1,0 +1,56 @@
+// Arduino.h, automatically included by the IDE, defines min and max macros
+// (which it shouldn't)
+#undef max
+#undef min
+
+#include "../../../lib/device/DeviceDescription.hpp"
+#include "../../../lib/storage/Storage.hpp"
+const int kLedPin = 0;
+
+// Common descriptions
+const DeviceDescription *const bike = new DeviceDescription(30, {Bright});
+const DeviceDescription *const scarf = new DeviceDescription(46, {});
+const DeviceDescription *const lantern = new DeviceDescription(5, {Tiny});
+const DeviceDescription *const puck =
+    new DeviceDescription(12, {Tiny, Circular});
+const DeviceDescription *const two_side_puck =
+    new DeviceDescription(24, {Tiny, Circular, Mirrored});
+
+const DeviceDescription *const device = two_side_puck;
+
+bool successful_write;
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(kLedPin, OUTPUT);
+
+  Serial.print("Writing DeviceDescription version ");
+  Serial.print(device->description_version);
+  Serial.println("...");
+  successful_write = PutDeviceDescription(device);
+
+  if (successful_write) {
+    Serial.println("Write successful!");
+  } else {
+    Serial.println("Write failed!");
+  }
+}
+
+void loop() {
+  if (successful_write) {
+    for (uint8_t i = 0; i < 2; ++i) {
+      digitalWrite(kLedPin, HIGH);
+      delay(200);
+      digitalWrite(kLedPin, LOW);
+      delay(200);
+    }
+
+    while (true) {
+    }
+  }
+
+  digitalWrite(kLedPin, HIGH);
+  delay(200);
+  digitalWrite(kLedPin, LOW);
+  delay(200);
+}


### PR DESCRIPTION
The DeviceDescription is stored and read from flash memory. If the
description is of an unrecognized version, a fallback description is
used and the startup animation is red to indicate an error.