### PR TITLE
Don't set board LED

### DIFF
--- a/lib/device/DeviceDescription.cpp
+++ b/lib/device/DeviceDescription.cpp
@@ -6,5 +6,13 @@
 
 DeviceDescription::DeviceDescription(
     uint32_t milliamps_supported,
-    const std::vector<const StripDescription*> strips)
+    const std::vector<const StripDescription *> strips)
     : milliamps_supported(milliamps_supported), strips(strips) {}
+
+uint8_t DeviceDescription::GetLedCount() const {
+  uint16_t led_count = 0;
+  for (const StripDescription *strip : strips) {
+    led_count += strip->led_count;
+  }
+  return led_count;
+}

--- a/lib/device/DeviceDescription.hpp
+++ b/lib/device/DeviceDescription.hpp
@@ -20,5 +20,7 @@ class DeviceDescription {
 
   DeviceDescription(const uint32_t milliamps_supported,
                     const std::vector<const StripDescription*> strips);
+
+  uint8_t GetLedCount() const;
 };
 #endif  // __DEVICE_DESCRIPTION_HPP__

--- a/src/arduino/FastLedManager.cpp
+++ b/src/arduino/FastLedManager.cpp
@@ -7,13 +7,11 @@
 FastLedManager::FastLedManager(const DeviceDescription *device,
                                RadioStateMachine *radio_state)
     : LedManager(device, radio_state) {
-  uint16_t led_count = 0;
-  for (const StripDescription *strip : device->strips) {
-    led_count += strip->led_count;
-  }
+  uint16_t led_count = device->GetLedCount();
 
-  // The first LED is on-board, and should mirror the first LED of the strip.
+  // The first LED is on-board, and only serves as a bit shift pass through.
   leds = new CRGB[led_count + 1];
+  leds[0] = CRGB::Black;
   FastLED.addLeds<NEOPIXEL, WS2812_PIN>(leds, led_count + 1)
       .setCorrection(TypicalLEDStrip);
   FastLED.setMaxPowerInVoltsAndMilliamps(5, device->milliamps_supported);
@@ -23,10 +21,7 @@ FastLedManager::FastLedManager(const DeviceDescription *device,
 void FastLedManager::SetGlobalColor(CRGB rgb) { FastLED.showColor(rgb); }
 
 void FastLedManager::PlayStartupAnimation() {
-  uint16_t led_count = 0;
-  for (const StripDescription *strip : device->strips) {
-    led_count += strip->led_count;
-  }
+  uint16_t led_count = device->GetLedCount();
 
   CRGB white = CRGB(128, 128, 128);
   for (uint8_t i = 0; i < led_count * 2; ++i) {
@@ -42,8 +37,9 @@ void FastLedManager::PlayStartupAnimation() {
 }
 
 void FastLedManager::SetLed(uint8_t led_index, CRGB *const rgb) {
-  // The first LED is on-board, and should mirror the first LED of the strip.
-  if (led_index == 0) {
+  // If we only have one LED then treat the board LED as the first LED. This is
+  // useful for testing boards themselves.
+  if (device->GetLedCount() == 1 && led_index == 0) {
     leds[0] = *rgb;
   }
   leds[led_index + 1] = *rgb;

--- a/src/devices/node/node.cpp
+++ b/src/devices/node/node.cpp
@@ -37,8 +37,9 @@ const DeviceDescription *const rainbow_cloak = new DeviceDescription(
         new StripDescription(94, {}),
         new StripDescription(11, {Tiny, Circular, Reversed}),
     });
+const DeviceDescription *const backpack_tail = SimpleRfBoardDescription(11, {});
 
-const DeviceDescription *const device = rainbow_cloak;
+const DeviceDescription *const device = scarf;
 
 RadioHeadRadio *radio;
 NetworkManager *nm;

--- a/src/generic/test/EffectsTest.cpp
+++ b/src/generic/test/EffectsTest.cpp
@@ -57,5 +57,6 @@ TEST(Effects, multipleStrips) {
   DeviceDescription device = DeviceDescription(
       2000, {new StripDescription(20, {}), new StripDescription(10, {Tiny}),
              new StripDescription(12, {Circular})});
+  EXPECT_EQ(device.GetLedCount(), 42);
   runEffectsTest(&device, 60 * 1000);
 }

--- a/src/generic/test/LedManagerTest.cpp
+++ b/src/generic/test/LedManagerTest.cpp
@@ -10,6 +10,7 @@
 TEST(LedManager, hasNonRandomEffects) {
   StripDescription strip = StripDescription(1, {});
   DeviceDescription device = DeviceDescription(2000, {&strip});
+  EXPECT_EQ(device.GetLedCount(), 1);
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *state_machine = new RadioStateMachine(networkManager);
@@ -47,6 +48,7 @@ TEST(LedManager, hasNonRandomEffects) {
 TEST(LedManager, effectIndexIsInRange) {
   StripDescription strip = StripDescription(1, {});
   DeviceDescription device = DeviceDescription(2000, {&strip});
+  EXPECT_EQ(device.GetLedCount(), 1);
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *state_machine = new RadioStateMachine(networkManager);
@@ -68,6 +70,7 @@ class TestEffect : public Effect {
 TEST(LedManager, callStripInReverse) {
   StripDescription strip = StripDescription(5, {Reversed});
   DeviceDescription device = DeviceDescription(2000, {&strip});
+  EXPECT_EQ(device.GetLedCount(), 5);
   FakeRadio radio;
   NetworkManager *networkManager = new NetworkManager(&radio);
   RadioStateMachine *state_machine = new RadioStateMachine(networkManager);


### PR DESCRIPTION
The board LED only serves as a pass-through.

Added DeviceDescription::GetLedCount() to reduce copy-paste.