### PR TITLE
Fix left-shift errors

### DIFF
--- a/lib/effect/LightningEffect.cpp
+++ b/lib/effect/LightningEffect.cpp
@@ -14,7 +14,7 @@ CRGB LightningEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
   ColorPalette palette = palettes[palette_index];
 
   uint8_t noise = perlinNoise(led_index << 6, time_ms / 6);
-  CHSV color = palette.GetGradient(((noise - 160) << 9) + time_ms);
+  CHSV color = palette.GetGradient(((noise - 160) * 512) + time_ms);
   if (noise > 160) {
     color.v = noise;
   } else {

--- a/lib/math/Perlin.hpp
+++ b/lib/math/Perlin.hpp
@@ -51,7 +51,7 @@ inline uint8_t perlinNoise(uint32_t x, uint32_t y) {
                           ease8InOutApprox(fy));
 
   // Scale and normalize noise.
-  val = val << 2;
+  val *= 4;
   val += 128;
   if (val >= 256) {
     val = 255;


### PR DESCRIPTION
We were trying to left shift negative numbers. This fixes smalltests so
we no longer try to left shift any negative numbers.

Fixes #37