### PR TITLE
Move initialization out of the RadioHeadRadio constructor.

### DIFF
--- a/lib/radio/Radio.hpp
+++ b/lib/radio/Radio.hpp
@@ -86,7 +86,7 @@ class Radio {
   virtual ~Radio(){};
 
   /**
-   * If a packet is avilable, reads it into the provided struct and return
+   * If a packet is available, reads it into the provided struct and returns
    * true. If no packet is available, returns false.
    */
   virtual bool readPacket(RadioPacket& packet) = 0;

--- a/src/arduino/FastLedManager.cpp
+++ b/src/arduino/FastLedManager.cpp
@@ -36,6 +36,15 @@ void FastLedManager::PlayStartupAnimation() {
   }
 }
 
+void FastLedManager::FatalErrorAnimation() {
+  while (true) {
+    FastLED.showColor(CRGB(64, 0, 0));
+    delay(100);
+    FastLED.showColor(CRGB(0, 0, 0));
+    delay(100);
+  }
+}
+
 void FastLedManager::SetLed(uint8_t led_index, const CRGB &rgb) {
   // If we only have one LED then treat the board LED as the first LED. This is
   // useful for testing boards themselves.

--- a/src/arduino/FastLedManager.hpp
+++ b/src/arduino/FastLedManager.hpp
@@ -17,6 +17,9 @@ class FastLedManager : public LedManager {
 
   void PlayStartupAnimation();
 
+  // Blinks the LEDs red. Never returns; call upon unrecoverable error.
+  void FatalErrorAnimation();
+
   void SetLed(uint8_t led_index, const CRGB &rgb) override;
 
   void SetOnboardLed(const CRGB &rgb);

--- a/src/arduino/RadioHeadRadio.cpp
+++ b/src/arduino/RadioHeadRadio.cpp
@@ -4,11 +4,15 @@
 
 #include <Debug.hpp>
 
-RadioHeadRadio::RadioHeadRadio() {
-  radio.init();
+bool RadioHeadRadio::Begin() {
+  if (!radio.init()) {
+    debug_printf("Failed to initialize radio");
+    return false;
+  }
   radio.setTxPower(13, false);
   radio.setFrequency(915.0);
   radio.available();
+  return true;
 }
 
 bool RadioHeadRadio::readPacket(RadioPacket &packet) {

--- a/src/arduino/RadioHeadRadio.hpp
+++ b/src/arduino/RadioHeadRadio.hpp
@@ -12,7 +12,11 @@ const int kFrontPacketPadding = 3;
 
 class RadioHeadRadio : public Radio {
  public:
-  RadioHeadRadio();
+  RadioHeadRadio() {}
+
+  // Initializes the hardware. Call before using this class. Returns true on
+  // success.
+  bool Begin();
 
   // Overrides
   bool readPacket(RadioPacket &packet) override;

--- a/src/devices/dmx/dmx.cpp
+++ b/src/devices/dmx/dmx.cpp
@@ -24,6 +24,14 @@ void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
 
   radio = new RadioHeadRadio();
+  if (!radio->Begin()) {
+    bool on = false;
+    while (true) {
+      digitalWrite(LED_BUILTIN, on);
+      delay(100);
+      on = !on;
+    }
+  }
   radio->sleep();
 
   Serial.println("Starting...");

--- a/src/devices/fancy-node/fancy-node.cc
+++ b/src/devices/fancy-node/fancy-node.cc
@@ -66,8 +66,12 @@ void setup() {
   radio = new RadioHeadRadio();
   nm = new NetworkManager(radio);
   state_machine = new RadioStateMachine(nm);
-
   led_manager = new FastLedManager(Devices::current, state_machine);
+
+  if (!radio->Begin()) {
+    led_manager->FatalErrorAnimation();
+  }
+
   led_manager->PlayStartupAnimation();
 }
 

--- a/src/devices/node/node.cpp
+++ b/src/devices/node/node.cpp
@@ -32,9 +32,13 @@ void setup() {
   state_machine = new RadioStateMachine(nm);
 
   led_manager = new FastLedManager(device, state_machine);
+
+  if (!radio->Begin()) {
+    led_manager->FatalErrorAnimation();
+  }
+
   // NOTE: can check if we watchdog rebooted by checking REG_PM_RCAUSE
   // See https://github.com/gjt211/SAMD21-Reset-Cause
-
   led_manager->PlayStartupAnimation();
 
   // Set up the watchdog timer: this will reset the processor if it hasn't

--- a/src/devices/range_test/range_test.cc
+++ b/src/devices/range_test/range_test.cc
@@ -29,9 +29,10 @@ void setup() {
   nm = new NetworkManager(radio);
   state_machine = new RadioStateMachine(nm);
   led_manager = new FastLedManager(&device, state_machine);
-  // Yellow LED on boot indicates a problem initializing the radio
-  led_manager->SetGlobalColor(CHSV(HUE_YELLOW, 255, 128));
-  led_manager->SetGlobalColor(CRGB(CRGB::Black));
+
+  if (!radio->Begin()) {
+    led_manager->FatalErrorAnimation();
+  }
 
   packetToSend.writeSetEffect(0, 10, 4);
 }

--- a/src/devices/remote/remote.ino
+++ b/src/devices/remote/remote.ino
@@ -13,6 +13,14 @@ void setup() {
   pinMode(kButton0, INPUT_PULLUP);
 
   radio = new RadioHeadRadio();
+  if (!radio->Begin()) {
+    bool on = false;
+    while (true) {
+      digitalWrite(kLedPin, on);
+      delay(100);
+      on = !on;
+    }
+  }
   radio->sleep();
 }
 

--- a/src/devices/trellis/trellis.ino
+++ b/src/devices/trellis/trellis.ino
@@ -49,10 +49,11 @@ void setup() {
   stateMachine = new RadioStateMachine(nm);
 
   ledManager = new FastLedManager(kNumLeds, DeviceType::Wearable, stateMachine);
+  if (!radio->Begin()) {
+    ledManager->FatalErrorAnimation();
+  }
 
   initTrellis();
-
-  ledManager->SetGlobalColor(CRGB(CRGB::Black));
   colorPaletteEffect = new DisplayColorPaletteEffect(1, DeviceType::Wearable);
 }
 


### PR DESCRIPTION
    This moves the init logic into a `Begin` method. This is cleaner: it
    decouples instantiating the object from the hardware initialization, and
    allows the `Begin` method to return whether it succeeded.
