### PR TITLE
Use raw objects, not pointers, for Firefly classes.

### DIFF
--- a/lib/device/Devices.hpp
+++ b/lib/device/Devices.hpp
@@ -45,7 +45,7 @@ const DeviceDescription *const hex_light =
     SimpleRfBoardDescription(12, {Circular, Tiny});
 
 // Modify this variable to easily switch between devices.
-const DeviceDescription *const current = scarf;
+const DeviceDescription *const current = bike;
 
 }  // namespace Devices
 

--- a/lib/effect/ColorCycleEffect.cpp
+++ b/lib/effect/ColorCycleEffect.cpp
@@ -10,7 +10,7 @@ CRGB ColorCycleEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
   UNUSED(led_index);
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  const ColorPalette palette = palettes[palette_index];
+  const ColorPalette palette = palettes()[palette_index];
   // Check for whether the entire palette is the same color - if so, change the
   // brightness rather than the hue.
   if (palette.Size() < 2) {

--- a/lib/effect/ContrastBumpsEffect.cpp
+++ b/lib/effect/ContrastBumpsEffect.cpp
@@ -9,7 +9,7 @@ CRGB ContrastBumpsEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
                                  RadioPacket *setEffectPacket) {
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  ColorPalette palette = palettes[palette_index];
+  ColorPalette palette = palettes()[palette_index];
 
   uint8_t led_count = strip->led_count;
   if (strip->FlagEnabled(Mirrored)) {

--- a/lib/effect/DisplayColorPaletteEffect.cpp
+++ b/lib/effect/DisplayColorPaletteEffect.cpp
@@ -7,7 +7,7 @@ CRGB DisplayColorPaletteEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
                                        RadioPacket *setEffectPacket) {
   UNUSED(led_index);
   ColorPalette palette =
-      palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
+      palettes()[setEffectPacket->readPaletteIndexFromSetEffect()];
   CHSV color = palette.GetGradient((time_ms / 2) * 23);
   if (!strip->FlagEnabled(Bright)) {
     color.v /= 2;

--- a/lib/effect/Effect.cpp
+++ b/lib/effect/Effect.cpp
@@ -12,6 +12,9 @@ uint8_t Effect::GetThresholdSin(int16_t x, uint8_t threshold) {
   }
 }
 
+// If this is a simple static variable, then it might not be initialized before
+// it's used, static variable initialization order is undefined. This method
+// ensures that it is initialized when it's used.
 const std::vector<ColorPalette> Effect::palettes() {
   static const std::vector<ColorPalette> palettes = {
       // Solid color

--- a/lib/effect/Effect.cpp
+++ b/lib/effect/Effect.cpp
@@ -12,50 +12,53 @@ uint8_t Effect::GetThresholdSin(int16_t x, uint8_t threshold) {
   }
 }
 
-const std::vector<ColorPalette> Effect::palettes = {
-    // Solid color
-    {{HUE_RED, 255, 255}},
-    {{HUE_ORANGE, 255, 255}},
-    {{HUE_YELLOW, 255, 255}},
-    {{HUE_GREEN, 255, 255}},
-    {{HUE_AQUA, 255, 255}},
-    {{HUE_BLUE, 255, 255}},
-    {{HUE_PURPLE, 255, 255}},
-    {{HUE_PINK, 255, 255}},
+const std::vector<ColorPalette> Effect::palettes() {
+  static const std::vector<ColorPalette> palettes = {
+      // Solid color
+      {{HUE_RED, 255, 255}},
+      {{HUE_ORANGE, 255, 255}},
+      {{HUE_YELLOW, 255, 255}},
+      {{HUE_GREEN, 255, 255}},
+      {{HUE_AQUA, 255, 255}},
+      {{HUE_BLUE, 255, 255}},
+      {{HUE_PURPLE, 255, 255}},
+      {{HUE_PINK, 255, 255}},
 
-    // Rainbow
-    {{HUE_RED, 255, 255}, {HUE_GREEN, 255, 255}, {HUE_BLUE, 255, 255}},
-    // Warm
-    {{HUE_RED, 255, 255}, {HUE_PURPLE, 255, 255}},
-    // Cool
-    {{HUE_GREEN, 255, 255}, {HUE_BLUE, 255, 255}},
-    // Yellow-green
-    {{HUE_YELLOW, 255, 255}, {HUE_AQUA, 255, 255}},
-    // 80s Miami
-    {{HUE_PURPLE, 255, 255}, {HUE_ORANGE, 255, 255}},
-    // Vaporwave
-    // https://i.redd.it/aepphltiqy911.png
-    {{33, 241, 249}, {247, 188, 255}, {201, 225, 160}, {153, 251, 150}},
-    // Popo
-    {{HUE_RED, 255, 255}, {HUE_BLUE, 255, 255}},
-    // Candy-cane
-    {{HUE_RED, 255, 255}, {HUE_RED, 0, 255}},
-    // Winter-mint candy-cane
-    {{HUE_AQUA, 255, 255}, {HUE_AQUA, 0, 255}},
-    // Fire
-    {{HUE_RED, 255, 255}, {HUE_ORANGE, 255, 255}, {HUE_YELLOW, 255, 255}},
-    // Pastel rainbow
-    {{HUE_RED, 127, 192}, {HUE_GREEN, 127, 192}, {HUE_BLUE, 127, 192}},
-    // Jazz cup - teal, purple, white
-    {{132, 255, 255}, {192, 255, 255}, {0, 0, 200}},
-    // Yellow and double purp
-    {{HUE_PURPLE, 255, 255}, {HUE_YELLOW, 255, 255}, {HUE_PURPLE, 255, 255}},
-    // Double rainbow (makes effects that depend on the number of colors, like
-    // swinging lights, do cool things)
-    {{HUE_RED, 255, 255},
-     {HUE_GREEN, 255, 255},
-     {HUE_BLUE, 255, 255},
-     {HUE_RED, 255, 255},
-     {HUE_GREEN, 255, 255},
-     {HUE_BLUE, 255, 255}},
-};
+      // Rainbow
+      {{HUE_RED, 255, 255}, {HUE_GREEN, 255, 255}, {HUE_BLUE, 255, 255}},
+      // Warm
+      {{HUE_RED, 255, 255}, {HUE_PURPLE, 255, 255}},
+      // Cool
+      {{HUE_GREEN, 255, 255}, {HUE_BLUE, 255, 255}},
+      // Yellow-green
+      {{HUE_YELLOW, 255, 255}, {HUE_AQUA, 255, 255}},
+      // 80s Miami
+      {{HUE_PURPLE, 255, 255}, {HUE_ORANGE, 255, 255}},
+      // Vaporwave
+      // https://i.redd.it/aepphltiqy911.png
+      {{33, 241, 249}, {247, 188, 255}, {201, 225, 160}, {153, 251, 150}},
+      // Popo
+      {{HUE_RED, 255, 255}, {HUE_BLUE, 255, 255}},
+      // Candy-cane
+      {{HUE_RED, 255, 255}, {HUE_RED, 0, 255}},
+      // Winter-mint candy-cane
+      {{HUE_AQUA, 255, 255}, {HUE_AQUA, 0, 255}},
+      // Fire
+      {{HUE_RED, 255, 255}, {HUE_ORANGE, 255, 255}, {HUE_YELLOW, 255, 255}},
+      // Pastel rainbow
+      {{HUE_RED, 127, 192}, {HUE_GREEN, 127, 192}, {HUE_BLUE, 127, 192}},
+      // Jazz cup - teal, purple, white
+      {{132, 255, 255}, {192, 255, 255}, {0, 0, 200}},
+      // Yellow and double purp
+      {{HUE_PURPLE, 255, 255}, {HUE_YELLOW, 255, 255}, {HUE_PURPLE, 255, 255}},
+      // Double rainbow (makes effects that depend on the number of colors, like
+      // swinging lights, do cool things)
+      {{HUE_RED, 255, 255},
+       {HUE_GREEN, 255, 255},
+       {HUE_BLUE, 255, 255},
+       {HUE_RED, 255, 255},
+       {HUE_GREEN, 255, 255},
+       {HUE_BLUE, 255, 255}},
+  };
+  return palettes;
+}

--- a/lib/effect/Effect.hpp
+++ b/lib/effect/Effect.hpp
@@ -17,7 +17,7 @@ class Effect {
                       const StripDescription *strip,
                       RadioPacket *setEffectPacket) = 0;
 
-  static const std::vector<ColorPalette> palettes;
+  static const std::vector<ColorPalette> palettes();
 
  protected:
   /**

--- a/lib/effect/FireflyEffect.cpp
+++ b/lib/effect/FireflyEffect.cpp
@@ -42,7 +42,7 @@ CRGB FireflyEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
     curve = 0;
   }
   ColorPalette palette =
-      palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
+      palettes()[setEffectPacket->readPaletteIndexFromSetEffect()];
   CHSV color = palette.GetGradient((time_ms / kBlinkPeriod) << 8);
   color.v = curve / 256;
   return color;

--- a/lib/effect/LightningEffect.cpp
+++ b/lib/effect/LightningEffect.cpp
@@ -11,7 +11,7 @@ CRGB LightningEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
   UNUSED(strip);
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  ColorPalette palette = palettes[palette_index];
+  ColorPalette palette = palettes()[palette_index];
 
   uint8_t noise = perlinNoise(led_index << 6, time_ms / 6);
   CHSV color = palette.GetGradient(((noise - 160) * 512) + time_ms);

--- a/lib/effect/RainbowBumpsEffect.cpp
+++ b/lib/effect/RainbowBumpsEffect.cpp
@@ -9,7 +9,7 @@ CRGB RainbowBumpsEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
                                 RadioPacket *setEffectPacket) {
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  ColorPalette palette = palettes[palette_index];
+  ColorPalette palette = palettes()[palette_index];
 
   uint8_t led_count = strip->led_count;
   if (strip->FlagEnabled(Mirrored)) {

--- a/lib/effect/RainbowEffect.cpp
+++ b/lib/effect/RainbowEffect.cpp
@@ -9,7 +9,7 @@ CRGB RainbowEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
 
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  ColorPalette palette = palettes[palette_index];
+  ColorPalette palette = palettes()[palette_index];
   // Check for whether the entire palette is the same color - if so, change the
   // brightness rather than the hue.
   if (palette.Size() < 2) {

--- a/lib/effect/RorschachEffect.cpp
+++ b/lib/effect/RorschachEffect.cpp
@@ -15,7 +15,7 @@ CRGB RorschachEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
                              RadioPacket *setEffectPacket) {
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  const ColorPalette palette = palettes[palette_index];
+  const ColorPalette palette = palettes()[palette_index];
 
   // LEDs at the center of the strip have a lower position.
   const uint16_t led_pos = -abs(led_index - (strip->led_count >> 1));

--- a/lib/effect/SimpleBlinkEffect.cpp
+++ b/lib/effect/SimpleBlinkEffect.cpp
@@ -9,7 +9,7 @@ CRGB SimpleBlinkEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
   const uint32_t chunk = (time_ms / (speed)) % 3;
   if (chunk == 0) {
     ColorPalette palette =
-        palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
+        palettes()[setEffectPacket->readPaletteIndexFromSetEffect()];
     CHSV color = palette.GetGradient((time_ms / 4) * 23);
     if (!strip->FlagEnabled(Bright)) {
       color.v /= 2;

--- a/lib/effect/SparkEffect.cpp
+++ b/lib/effect/SparkEffect.cpp
@@ -10,7 +10,7 @@ CRGB SparkEffect::GetRGB(uint8_t led_index, uint32_t time_ms,
   const uint8_t pulse_size = brightnesses.size();
   const uint8_t palette_index =
       setEffectPacket->readPaletteIndexFromSetEffect();
-  ColorPalette palette = palettes[palette_index];
+  ColorPalette palette = palettes()[palette_index];
 
   uint8_t led_count = strip->led_count;
   if (strip->FlagEnabled(Mirrored)) {

--- a/lib/effect/SwingingLights.cpp
+++ b/lib/effect/SwingingLights.cpp
@@ -39,7 +39,7 @@ CRGB SwingingLights::GetRGB(uint8_t led_index, uint32_t time_ms,
   const fract16 led_pos = (uint32_t)led_index * MAX_UINT16 / num_leds;
 
   ColorPalette palette =
-      palettes[setEffectPacket->readPaletteIndexFromSetEffect()];
+      palettes()[setEffectPacket->readPaletteIndexFromSetEffect()];
 
   CRGB color(0, 0, 0);
 

--- a/lib/led_manager/LedManager.cpp
+++ b/lib/led_manager/LedManager.cpp
@@ -35,7 +35,7 @@ LedManager::LedManager(const DeviceDescription *device,
   control_effect = new ControlEffect();
 
   radio_state->SetNumEffects(GetNumEffects());
-  radio_state->SetNumPalettes(effects[0]->palettes.size());
+  radio_state->SetNumPalettes(Effect::palettes().size());
 }
 
 LedManager::~LedManager() {

--- a/src/devices/dmx/dmx.cpp
+++ b/src/devices/dmx/dmx.cpp
@@ -8,7 +8,7 @@ const uint8_t DMX_CHANNELS = 192;
 const uint8_t RESERVATION_SECONDS = 5;
 const uint8_t UPDATE_TIMEOUT_SECONDS = 1;
 
-RadioHeadRadio* radio;
+RadioHeadRadio *radio = new RadioHeadRadio();
 
 SparkFunDMX dmx;
 
@@ -23,7 +23,6 @@ void setup() {
 
   pinMode(LED_BUILTIN, OUTPUT);
 
-  radio = new RadioHeadRadio();
   if (!radio->Begin()) {
     bool on = false;
     while (true) {

--- a/src/devices/node/node.cpp
+++ b/src/devices/node/node.cpp
@@ -14,8 +14,8 @@
 
 const int kLedPin = 0;
 
-// Note: `RadioHeadRadio` needs to be a pointer, I think because the superclass
-// `Radio` is abstract (has pure virtual methods)
+// Note: `RadioHeadRadio` needs to be a pointer - if it's an object, the node
+// crashes upon receiving a packet.
 RadioHeadRadio *radio = new RadioHeadRadio();
 NetworkManager nm(radio);
 RadioStateMachine state_machine(&nm);
@@ -27,9 +27,6 @@ void setup() {
   Serial.begin(115200);
   pinMode(kLedPin, OUTPUT);
 
-  // nm = new NetworkManager(radio);
-  // state_machine = new RadioStateMachine(nm);
-  // led_manager = new FastLedManager(Devices::current, state_machine);
   if (!radio->Begin()) {
     led_manager.FatalErrorAnimation();
   }

--- a/src/devices/remote/remote.ino
+++ b/src/devices/remote/remote.ino
@@ -3,7 +3,7 @@
 const int kLedPin = 0;
 const int kButton0 = 8;
 
-RadioHeadRadio* radio;
+RadioHeadRadio *radio = new RadioHeadRadio();
 RadioPacket packet;
 
 void setup() {
@@ -12,7 +12,6 @@ void setup() {
   pinMode(kLedPin, OUTPUT);
   pinMode(kButton0, INPUT_PULLUP);
 
-  radio = new RadioHeadRadio();
   if (!radio->Begin()) {
     bool on = false;
     while (true) {

--- a/src/generic/RadioStateMachine.hpp
+++ b/src/generic/RadioStateMachine.hpp
@@ -49,7 +49,7 @@ class RadioStateMachine {
   /** Runs the radio state machine. Typically you want to use just Tick. */
   void RadioTick();
 
-  // Network properties - these are used to coordinate effectrs
+  // Network properties - these are used to coordinate effects
 
   /** Returns the synchronized milliseconds time from the network. */
   uint32_t GetNetworkMillis();


### PR DESCRIPTION
This is less error prone, since it relies on the natural object lifecycle.