### PR TITLE
Fix timing bug

### DIFF
--- a/lib/effect/Effect.cpp
+++ b/lib/effect/Effect.cpp
@@ -15,7 +15,7 @@ uint8_t Effect::GetThresholdSin(int16_t x, uint8_t threshold) {
 // If this is a simple static variable, then it might not be initialized before
 // it's used, static variable initialization order is undefined. This method
 // ensures that it is initialized when it's used.
-const std::vector<ColorPalette> Effect::palettes() {
+const std::vector<ColorPalette>& Effect::palettes() {
   static const std::vector<ColorPalette> palettes = {
       // Solid color
       {{HUE_RED, 255, 255}},

--- a/lib/effect/Effect.hpp
+++ b/lib/effect/Effect.hpp
@@ -17,7 +17,7 @@ class Effect {
                       const StripDescription &strip,
                       RadioPacket *setEffectPacket) = 0;
 
-  static const std::vector<ColorPalette> palettes();
+  static const std::vector<ColorPalette>& palettes();
 
  protected:
   /**

--- a/lib/effect/Effect.hpp
+++ b/lib/effect/Effect.hpp
@@ -17,7 +17,7 @@ class Effect {
                       const StripDescription &strip,
                       RadioPacket *setEffectPacket) = 0;
 
-  static const std::vector<ColorPalette>& palettes();
+  static const std::vector<ColorPalette> &palettes();
 
  protected:
   /**


### PR DESCRIPTION
Before the `palettes()` function would take a really long time to index into the array for some reason. But adding a reference helps!