### PR TITLE
Fix battery logic on fancy-node

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,8 +46,9 @@ build_flags =
 lib_deps = 
 	mikem/RadioHead@^1.120
 	https://github.com/ademuri/FakeFastLED.git#199cd546998d11a47887850f06ecf7955a08c85f ; stm32g0 branch
-	ademuri/smart-input-filter@^0.3.2
+	https://github.com/ademuri/smart-input-filter#387449460ded187b91090cbf5bfe8b5a9121b26f ; v0.6.0
 	https://github.com/candykingdom/FlashStorage_STM32.git#02794dba88825fa01af3acf6f638f891b8ed2774
+	https://github.com/ademuri/arduino-timer.git#cb86833
 
 [env:fancy-node]
 extends = fancy-node-base

--- a/src/arduino/FastLedManager.cpp
+++ b/src/arduino/FastLedManager.cpp
@@ -11,11 +11,10 @@ FastLedManager::FastLedManager(const DeviceDescription &device,
 
   // The first LED is on-board, and only serves as a bit shift pass through.
   leds = new CRGB[led_count + 1];
-  leds[0] = CRGB::Black;
   FastLED.addLeds<NEOPIXEL, WS2812_PIN>(leds, led_count + 1)
       .setCorrection(TypicalLEDStrip);
   FastLED.setMaxPowerInVoltsAndMilliamps(5, device.milliamps_supported);
-  FastLED.showColor(CRGB(0, 0, 0));
+  FastLED.clear(/*writeData=*/true);
 }
 
 void FastLedManager::SetGlobalColor(const CRGB &rgb) { FastLED.showColor(rgb); }
@@ -34,6 +33,7 @@ void FastLedManager::PlayStartupAnimation() {
     FastLED.show();
     delay(500 / led_count);
   }
+  FastLED.clear(/*writeData=*/true);
 }
 
 void FastLedManager::FatalErrorAnimation() {

--- a/src/devices/fancy-node/fancy-node.cc
+++ b/src/devices/fancy-node/fancy-node.cc
@@ -188,10 +188,6 @@ void setup() {
 
   analogReadResolution(10);
 
-  // For some reason, if there's more than a ~1s delay before running this for
-  // the first time, it hangs.
-  state_machine.Tick();
-
   bool button_still_pressed = !(digitalRead(kButton1) && digitalRead(kButton2));
   if (button_pressed && button_still_pressed) {
     led_manager->SetOnboardLed(CHSV(0, 0, 32));

--- a/src/devices/fancy-node/fancy-node.cc
+++ b/src/devices/fancy-node/fancy-node.cc
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <FastLED.h>
 #include <FlashStorage_STM32.h>
+#include <arduino-timer.h>
 #include <exponential-moving-average-filter.h>
 #include <median-filter.h>
 
@@ -14,38 +15,64 @@
 #include "../../generic/NetworkManager.hpp"
 #include "../../generic/RadioStateMachine.hpp"
 
-constexpr DeviceMode kDeviceMode = DeviceMode::READ_FROM_FLASH;
+constexpr DeviceMode kDeviceMode = DeviceMode::CURRENT_FROM_HEADER;
 
-const int kLedPin = PB0;
-const int kNeopixelPin = PA12;
-const int kBatteryPin = PA0;
-
-const DeviceDescription test_device =
-    Devices::SimpleRfBoardDescription(1, {Bright});
+constexpr int kLedPin = PB0;
+constexpr int kNeopixelPin = PA12;
+constexpr int kBatteryPin = PA0;
+constexpr int kButton1 = PB1;
+constexpr int kButton2 = PB2;
 
 RadioHeadRadio *radio = new RadioHeadRadio();
 NetworkManager nm(radio);
 RadioStateMachine state_machine(&nm);
 FastLedManager *led_manager;
 
-// val = (previous * 3 + current) / 4
-static constexpr uint8_t kBatteryFilterAlpha = 96;
-MedianFilter<uint16_t, uint16_t, 5> battery_median_filter{
-    filter_functions::ForAnalogRead<kBatteryPin>()};
+// Heavy filtering
+static constexpr uint8_t kBatteryFilterAlpha = 1;
+static constexpr uint8_t kBatteryMedianFilterSize = 5;
+MedianFilter<uint16_t, uint16_t, kBatteryMedianFilterSize>
+    battery_median_filter{filter_functions::ForAnalogRead<kBatteryPin>()};
 ExponentialMovingAverageFilter<uint16_t> battery_average_filter{
     []() { return battery_median_filter.GetFilteredValue(); },
     kBatteryFilterAlpha};
+bool battery_filters_initialized = false;
 
-static constexpr float kBatteryDead = 3.72;
+// On fancy-node v1.1, the filter cap on the battery voltage divider has a time
+// constant of ~0.5s, so when the device is cold-booted, it takes a couple of
+// seconds before the read battery level stabilizes. This timer ignores low
+// battery detection until that happens.
+CountDownTimer startup_battery_timer{3000};
+
+// References for battery level at startup. We can only really measure the
+// battery state-of-charge when the battery is unloaded, and has been unloaded
+// for at least a second or so. At startup, we check the approximate charge
+// level. We display this charge level on the onboard LED, and also put the
+// device into low power mode if the battery is effectively empty.
+static constexpr float kBatteryEmpty = 3.7;
 static constexpr float kBatteryFull = 4.2;
 
-// voltage = battery * 180 / (62 + 180) * 3.3 / 1024
-constexpr uint16_t kBatteryDividerHigh = 62;
-constexpr uint16_t kBatteryDividerLow = 180;
+// Cutoff under load. Since the LEDs may draw significant current (2-3A), the
+// under-load voltage could be significantly lower than the battery-empty
+// open-circuit voltage. 3V is a conservative cutoff voltage.
+static constexpr float kBatteryLowCutoff = 3.0;
+
+// Once we detect low battery, the battery must hit this voltage before turning
+// back on. This is about 50% charged (open voltage).
+static constexpr float kBatteryResume = 3.85;
+
+// voltage = battery * (62 + 180) / 180 * 3.3 / 1024
+constexpr float kBatteryDividerHigh = 62;
+constexpr float kBatteryDividerLow = 180;
 constexpr uint16_t BatteryVoltageToRawReading(float voltage) {
-  return voltage / (kBatteryDividerLow * 3.3 /
-                    (kBatteryDividerHigh + kBatteryDividerLow) / 1024);
+  const float divided_voltage =
+      voltage /
+      ((kBatteryDividerHigh + kBatteryDividerLow) / kBatteryDividerLow);
+  return divided_voltage / 3.3 * 1024.0;
 }
+
+uint16_t battery_at_boot = 0;
+bool battery_low = false;
 
 FastLedManager *ReadDeviceFromFlash() {
   DeviceDescription *device =
@@ -61,8 +88,8 @@ FastLedManager *ReadDeviceFromFlash() {
   }
 
   if (device->check_value != DeviceDescription::kCheckValue) {
-    Serial.print("Got invalid check value when reading DeviceDescription: ");
-    Serial.println(device->check_value);
+    Serial2.print("Got invalid check value when reading DeviceDescription: ");
+    Serial2.println(device->check_value);
     return new FastLedManager(Devices::current, &state_machine);
   }
   return new FastLedManager(*device, &state_machine);
@@ -90,6 +117,14 @@ void WriteDeviceToFlash() {
   EEPROM.commit();
 }
 
+void LowBatteryMode() {
+  FastLED.clearData();
+  led_manager->SetOnboardLed(CRGB(4, 0, 0));
+  FastLED.leds()[1] = CRGB(4, 0, 0);
+  FastLED.show();
+  radio->sleep();
+}
+
 void setup() {
   // check if nBOOT_SEL bit is set
   if (FLASH->OPTR & FLASH_OPTR_nBOOT_SEL) {
@@ -113,13 +148,17 @@ void setup() {
 
   pinMode(kLedPin, OUTPUT);
   digitalWrite(kLedPin, HIGH);
-
   Serial2.begin(115200);
   Serial2.println("Booting...");
 
-  analogReadResolution(10);
-  battery_median_filter.SetMinRunInterval(10);
-  battery_average_filter.SetMinRunInterval(10);
+  startup_battery_timer.Reset();
+
+  pinMode(kBatteryPin, INPUT);
+  pinMode(kButton1, INPUT_PULLUP);
+  pinMode(kButton2, INPUT_PULLUP);
+
+  // Note: buttons are inverted (low is pressed)
+  bool button_pressed = !(digitalRead(kButton1) && digitalRead(kButton2));
 
   SPI.setMISO(PA6);
   SPI.setMOSI(PA7);
@@ -147,35 +186,81 @@ void setup() {
     led_manager->FatalErrorAnimation();
   }
 
+  analogReadResolution(10);
+
+  // For some reason, if there's more than a ~1s delay before running this for
+  // the first time, it hangs.
+  state_machine.Tick();
+
+  bool button_still_pressed = !(digitalRead(kButton1) && digitalRead(kButton2));
+  if (button_pressed && button_still_pressed) {
+    led_manager->SetOnboardLed(CHSV(0, 0, 32));
+    FastLED.show();
+    // Give time for the battery input filter capacitor to charge.
+    // TODO: remove this for fancy-node v1.2
+    delay(2000);
+    battery_at_boot = analogRead(kBatteryPin);
+  }
+
   led_manager->PlayStartupAnimation();
   digitalWrite(kLedPin, LOW);
 }
 
 void loop() {
-  battery_median_filter.Run();
-  battery_average_filter.Run();
-  if (battery_average_filter.GetFilteredValue() <
-      BatteryVoltageToRawReading(kBatteryDead)) {
-    // TODO: display a battery-low pattern?
-    FastLED.clearData();
-    led_manager->SetOnboardLed(CRGB(8, 0, 0));
-    FastLED.show();
-  } else {
-    // Display battery status on onboard LED for the first 20 seconds
-    if (millis() < 20 * 1000) {
-      uint16_t battery_val = battery_average_filter.GetFilteredValue() -
-                             BatteryVoltageToRawReading(kBatteryDead);
-      uint16_t battery_range = BatteryVoltageToRawReading(kBatteryFull) -
-                               BatteryVoltageToRawReading(kBatteryDead);
-      // Red is hue 0
-      uint8_t hue = (battery_val * HUE_GREEN) / battery_range;
-      led_manager->SetOnboardLed(CHSV(hue, 255, 255));
-    } else {
-      led_manager->SetOnboardLed(CRGB::Black);
+  digitalWrite(kLedPin, ((millis() / 200) % 5) == 0);
+
+  if (startup_battery_timer.Expired()) {
+    if (!battery_filters_initialized) {
+      for (uint8_t i = 0; i < kBatteryMedianFilterSize; i++) {
+        battery_median_filter.Run();
+      }
+      battery_average_filter.Initialize(analogRead(kBatteryPin));
+      battery_average_filter.Run();
+
+      battery_median_filter.SetMinRunInterval(100);
+      battery_average_filter.SetMinRunInterval(100);
+      battery_filters_initialized = true;
+    }
+    battery_median_filter.Run();
+    battery_average_filter.Run();
+
+    if (!battery_low && battery_average_filter.GetFilteredValue() <
+                            BatteryVoltageToRawReading(kBatteryLowCutoff)) {
+      battery_low = true;
+      LowBatteryMode();
     }
 
-    state_machine.Tick();
-    led_manager->RunEffect();
+    if (battery_low) {
+      if (battery_average_filter.GetFilteredValue() >
+          BatteryVoltageToRawReading(kBatteryResume)) {
+        battery_low = false;
+      } else {
+        delay(100);
+        return;
+      }
+    }
   }
+
+  // Display battery status on onboard LED for the first 20 seconds
+  if (battery_at_boot != 0 && millis() < 20 * 1000) {
+    uint16_t battery_val =
+        battery_at_boot - BatteryVoltageToRawReading(kBatteryEmpty);
+    constexpr uint16_t battery_range =
+        BatteryVoltageToRawReading(kBatteryFull) -
+        BatteryVoltageToRawReading(kBatteryEmpty);
+    static_assert(battery_range != 0);
+    if (battery_val > battery_range) {
+      battery_val = 0;
+    }
+
+    // Red is hue 0
+    uint8_t hue = (battery_val * HUE_GREEN) / battery_range;
+    led_manager->SetOnboardLed(CHSV(hue, 255, 255));
+  } else {
+    led_manager->SetOnboardLed(CRGB::Black);
+  }
+
+  state_machine.Tick();
+  led_manager->RunEffect();
   delay(5);
 }

--- a/src/generic/RadioStateMachine.cpp
+++ b/src/generic/RadioStateMachine.cpp
@@ -5,7 +5,7 @@
 #include <Effects.hpp>
 #include <cstdio>
 
-//#define DEBUG
+// #define DEBUG
 
 RadioStateMachine::RadioStateMachine(NetworkManager *networkManager)
     : network_manager_(networkManager) {
@@ -26,10 +26,16 @@ RadioState RadioStateMachine::GetCurrentState() { return state_; }
 void RadioStateMachine::Tick() {
   // Run the radio state machine twice, since writing out LEDs may take several
   // ms.
+  //
+  // There is a bug (probably a compiler bug) where if the first call to Tick()
+  // calls RadioTick() twice, in the second call the call to TimerExpired()
+  // hangs when it tries to access timers_. So, only call RadioTick once the
+  // first time Tick() is called.
   RadioTick();
-  if (millis() > 2000) {
+  if (tick_run_) {
     RadioTick();
   }
+  tick_run_ = true;
 }
 
 uint32_t RadioStateMachine::GetNetworkMillis() {

--- a/src/generic/RadioStateMachine.hpp
+++ b/src/generic/RadioStateMachine.hpp
@@ -144,6 +144,8 @@ class RadioStateMachine {
 
   RadioPacket packet_;
   RadioPacket set_effect_packet_;
+
+  bool tick_run_ = false;
 };
 
 #endif


### PR DESCRIPTION
Previously, the math for calculating the levels was incorrect. This fixes those calculations, and improves the logic.

Change-Id: Iac4724d2a1a70b19c8dfce0ac143243a275ae1e3