### PR TITLE
Add Dim and Off flags to strips

### DIFF
--- a/lib/device/Devices.hpp
+++ b/lib/device/Devices.hpp
@@ -56,12 +56,13 @@ const DeviceDescription backpack_rope = DeviceDescription(
                                StripDescription(96, {Dim, Reversed}),
                            });
 const DeviceDescription ufo = DeviceDescription(
-    RF_BOARD_MA_SUPPORTED, {
-                               StripDescription(12, {Circular}), // Top Circle
-                               StripDescription(16, {Circular}), // Bottom Circle
-                               StripDescription(12, {Bright, Circular}), // Bottom Lights
-                               StripDescription(52, {Dim, Circular}), // Rim
-                           });
+    RF_BOARD_MA_SUPPORTED,
+    {
+        StripDescription(12, {Circular}),          // Top Circle
+        StripDescription(16, {Circular}),          // Bottom Circle
+        StripDescription(12, {Bright, Circular}),  // Bottom Lights
+        StripDescription(52, {Dim, Circular}),     // Rim
+    });
 const DeviceDescription brooke_bike = DeviceDescription(
     RF_BOARD_MA_SUPPORTED, {
                                StripDescription(15, {Circular}),
@@ -69,7 +70,7 @@ const DeviceDescription brooke_bike = DeviceDescription(
                                StripDescription(16, {Circular}),
                                StripDescription(33, {Bright}),
                            });
-const DeviceDescription ross_backpack= DeviceDescription(
+const DeviceDescription ross_backpack = DeviceDescription(
     RF_BOARD_MA_SUPPORTED, {
                                StripDescription(13, {Reversed}),
                                StripDescription(12, {}),

--- a/lib/device/Devices.hpp
+++ b/lib/device/Devices.hpp
@@ -17,6 +17,7 @@ const DeviceDescription SimpleRfBoardDescription(uint8_t led_count,
 }
 
 const DeviceDescription bike = SimpleRfBoardDescription(30, {Bright});
+const DeviceDescription ben_s_bike = SimpleRfBoardDescription(28, {Bright});
 const DeviceDescription will_bike = SimpleRfBoardDescription(63, {Bright});
 const DeviceDescription scarf = SimpleRfBoardDescription(46, {});
 const DeviceDescription lantern = SimpleRfBoardDescription(5, {Tiny});
@@ -54,9 +55,32 @@ const DeviceDescription backpack_rope = DeviceDescription(
                                StripDescription(96, {Dim}),
                                StripDescription(96, {Dim, Reversed}),
                            });
+const DeviceDescription ufo = DeviceDescription(
+    RF_BOARD_MA_SUPPORTED, {
+                               StripDescription(12, {Circular}), // Top Circle
+                               StripDescription(16, {Circular}), // Bottom Circle
+                               StripDescription(12, {Bright, Circular}), // Bottom Lights
+                               StripDescription(52, {Dim, Circular}), // Rim
+                           });
+const DeviceDescription brooke_bike = DeviceDescription(
+    RF_BOARD_MA_SUPPORTED, {
+                               StripDescription(15, {Circular}),
+                               StripDescription(19, {}),
+                               StripDescription(16, {Circular}),
+                               StripDescription(33, {Bright}),
+                           });
+const DeviceDescription ross_backpack= DeviceDescription(
+    RF_BOARD_MA_SUPPORTED, {
+                               StripDescription(13, {Reversed}),
+                               StripDescription(12, {}),
+                               StripDescription(13, {Reversed}),
+                               StripDescription(12, {}),
+                           });
+
+const DeviceDescription whatever = SimpleRfBoardDescription(18, {Circular});
 
 // Modify this variable to easily switch between devices.
-const DeviceDescription &current = backpack_rope;
+const DeviceDescription &current = scarf;
 
 static_assert(sizeof(current) <= DeviceDescription::kMaxSize,
               "Current device too large");

--- a/lib/device/Devices.hpp
+++ b/lib/device/Devices.hpp
@@ -49,9 +49,14 @@ const DeviceDescription half_matrix_panel = DeviceDescription(
                                StripDescription(16, {}),
                                StripDescription(16, {Reversed}),
                            });
+const DeviceDescription backpack_rope = DeviceDescription(
+    RF_BOARD_MA_SUPPORTED, {
+                               StripDescription(96, {Dim}),
+                               StripDescription(96, {Dim, Reversed}),
+                           });
 
 // Modify this variable to easily switch between devices.
-const DeviceDescription &current = bike;
+const DeviceDescription &current = backpack_rope;
 
 static_assert(sizeof(current) <= DeviceDescription::kMaxSize,
               "Current device too large");

--- a/lib/device/StripDescription.hpp
+++ b/lib/device/StripDescription.hpp
@@ -7,6 +7,8 @@
 enum StripFlag {
   Tiny = 1 << 0,
   Bright = 1 << 1,
+  Dim = 1 << 6,
+  Off = 1 << 7,
   Circular = 1 << 2,
   Mirrored = 1 << 3,
   Reversed = 1 << 4,

--- a/lib/effect/Effect.cpp
+++ b/lib/effect/Effect.cpp
@@ -40,8 +40,8 @@ const std::vector<ColorPalette>& Effect::palettes() {
       // Vaporwave
       // https://i.redd.it/aepphltiqy911.png
       {{33, 241, 249}, {247, 188, 255}, {201, 225, 160}, {153, 251, 150}},
-      // Popo
-      {{HUE_RED, 255, 255}, {HUE_BLUE, 255, 255}},
+      // Cool, Formerly Popo but antifa got to them.
+      {{HUE_AQUA, 0, 255}, {HUE_BLUE, 255, 255}},
       // Candy-cane
       {{HUE_RED, 255, 255}, {HUE_RED, 0, 255}},
       // Winter-mint candy-cane

--- a/lib/led_manager/LedManager.cpp
+++ b/lib/led_manager/LedManager.cpp
@@ -22,7 +22,7 @@ LedManager::LedManager(const DeviceDescription &device,
   AddEffect(new SwingingLights(), 4);
 
   // Non-random effects
-  AddEffect(new PoliceEffect(), 0);
+  AddEffect(new SwingingLights(), 0); // Formerly police lights
   AddEffect(new StopLightEffect(), 0);
   // Strobes
   AddEffect(new SimpleBlinkEffect(60), 0);

--- a/lib/led_manager/LedManager.cpp
+++ b/lib/led_manager/LedManager.cpp
@@ -86,9 +86,19 @@ void LedManager::RunEffect() {
         virtual_index = strip_index;
       }
 
-      CRGB rgb = GetCurrentEffect()->GetRGB(virtual_index,
-                                            radio_state->GetNetworkMillis(),
-                                            strip, radio_state->GetSetEffect());
+      CRGB rgb;
+      if (!strip.FlagEnabled(Off)) {
+        rgb = GetCurrentEffect()->GetRGB(
+            virtual_index, radio_state->GetNetworkMillis(), strip,
+            radio_state->GetSetEffect());
+
+        if (strip.FlagEnabled(Dim)) {
+          rgb = rgb / (uint8_t)8;
+        }
+      } else {
+        rgb = CRGB::Black;
+      } 
+
       SetLed(global_index, rgb);
       global_index += 1;
     }

--- a/lib/led_manager/LedManager.cpp
+++ b/lib/led_manager/LedManager.cpp
@@ -22,7 +22,7 @@ LedManager::LedManager(const DeviceDescription &device,
   AddEffect(new SwingingLights(), 4);
 
   // Non-random effects
-  AddEffect(new SwingingLights(), 0); // Formerly police lights
+  AddEffect(new SwingingLights(), 0);  // Formerly police lights
   AddEffect(new StopLightEffect(), 0);
   // Strobes
   AddEffect(new SimpleBlinkEffect(60), 0);
@@ -90,9 +90,9 @@ void LedManager::RunEffect() {
       if (strip.FlagEnabled(Off)) {
         rgb = CRGB::Black;
       } else {
-        rgb = GetCurrentEffect()->GetRGB(
-            virtual_index, radio_state->GetNetworkMillis(), strip,
-            radio_state->GetSetEffect());
+        rgb = GetCurrentEffect()->GetRGB(virtual_index,
+                                         radio_state->GetNetworkMillis(), strip,
+                                         radio_state->GetSetEffect());
 
         if (strip.FlagEnabled(Dim)) {
           rgb = rgb / (uint8_t)8;

--- a/lib/led_manager/LedManager.cpp
+++ b/lib/led_manager/LedManager.cpp
@@ -87,7 +87,9 @@ void LedManager::RunEffect() {
       }
 
       CRGB rgb;
-      if (!strip.FlagEnabled(Off)) {
+      if (strip.FlagEnabled(Off)) {
+        rgb = CRGB::Black;
+      } else {
         rgb = GetCurrentEffect()->GetRGB(
             virtual_index, radio_state->GetNetworkMillis(), strip,
             radio_state->GetSetEffect());
@@ -95,9 +97,7 @@ void LedManager::RunEffect() {
         if (strip.FlagEnabled(Dim)) {
           rgb = rgb / (uint8_t)8;
         }
-      } else {
-        rgb = CRGB::Black;
-      } 
+      }
 
       SetLed(global_index, rgb);
       global_index += 1;


### PR DESCRIPTION
This makes it so we can dim devices or skip LEDs on a strip. God help you if you try to use Bright and Dim at the same time.

Also add backpack rope light definition.