### PR TITLE
Expand the gradient-flattening docs from the 004 fix

### DIFF
--- a/docs/led-effects.md
+++ b/docs/led-effects.md
@@ -44,9 +44,11 @@ virtual CRGB GetRGB(uint8_t led_index, uint32_t time_ms,
 
 `time_ms` is **network time** from `RadioStateMachine::GetNetworkMillis()` — the shared clock is what synchronizes animation across devices. Effects derive all motion from it (e.g. `time_ms/16`); per-device randomness (Fire, Firefly, Rorschach offsets) is seeded in constructors from `analogRead(A0)` on Arduino only, keeping host tests deterministic.
 
-Shared helpers: `Effect::palettes()` (Meyers singleton, the global palette table) and `GetThresholdSin(x, threshold)` (`Effect.cpp:5-13`) — a clamped/rescaled `sin16` used for discrete "bumps"; the negative half is always 0.
+Shared helpers: `Effect::palettes()` (Meyers singleton, the global palette table), `GetThresholdSin(x, threshold)` (`Effect.cpp:5-13`) — a clamped/rescaled `sin16` used for discrete "bumps"; the negative half is always 0 — and `FlattenedGradientRGB(CHSV)` (`Effect.cpp:15-32`), the gradient-power flattener described next.
 
-Rainbow, Color Cycle, Rainbow Bumps, and Display Color Palette convert interpolated palette colors with `FlattenedGradientRGB`, which scales out `hsv2rgb_rainbow`'s extra yellow-band power so smooth gradients do not contain a lone bright yellow LED. Exact palette colors, solid-color branches, and noise/texture effects deliberately retain FastLED's yellow boost.
+### Gradient power flattening (`FlattenedGradientRGB`)
+
+FastLED's `hsv2rgb_rainbow` deliberately over-drives hues in the yellow band (32–95) by up to ~34% total RGB power, which looks fine for solid colors but renders a smooth palette gradient with a lone over-bright yellow LED wherever the interpolation crosses that band (e.g. the rainbow palette's red→green blend). The four palette-showcase effects — Rainbow, Color Cycle, Rainbow Bumps, Display Color Palette — convert their interpolated gradient colors through `FlattenedGradientRGB`, which rescales any converted color whose `r+g+b` exceeds the un-boosted (red-hue) baseline at the same saturation/value, so gradients drive uniform power. Noise/texture effects (Fire, Perlin-based, sparks) and exact palette stops via `GetColor` deliberately keep FastLED's boost — it's part of their look. The property is pinned on both sides by `test/GradientPowerTest.cpp` and `sim/test/cases/gradientPower.test.mjs` (specs/004-fix-yellow-spike).
 
 ## Effect catalog (`lib/effect/`)
 

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -22,7 +22,7 @@ Programmatic driving (browser console or automation): `window.sim` — e.g. `sim
 node --test "sim/test/cases/*.test.mjs"   # or: npm test
 ```
 
-Seven suites: wire-index registry invariants (incl. the "Display Color Palette / Dark are the last two indices" invariant), determinism, central strip-flag handling (Reversed/Dim/Off), 0–255 wire-byte fuzz, SET_CONTROL semantics, master cadence/weighting, and byte-exact comparison against `sim/test/vectors/reference.json`. The same cases run in-browser at `/test.html` (it reports `window.__testResults` and beacons `/__test-results?pass=N&fail=M` to the serving host for automated drivers).
+Eight suites: wire-index registry invariants (incl. the "Display Color Palette / Dark are the last two indices" invariant), determinism, central strip-flag handling (Reversed/Dim/Off), 0–255 wire-byte fuzz, SET_CONTROL semantics, master cadence/weighting, uniform gradient drive (the specs/004 power flattening, mirroring `test/GradientPowerTest.cpp`), and byte-exact comparison against `sim/test/vectors/reference.json`. The same cases run in-browser at `/test.html` (it reports `window.__testResults` and beacons `/__test-results?pass=N&fail=M` to the serving host for automated drivers).
 
 ## Lint it
 


### PR DESCRIPTION
## Summary

The 004 yellow-spike fix landed on master as d58a8a7 while this PR was in flight (same implementation — this branch's version was verified byte-identical: same helper, call sites, corpus, and tests). After rebasing, this PR carries the residual documentation improvements:

- **docs/led-effects.md**: a dedicated "Gradient power flattening" section — why `hsv2rgb_rainbow`'s yellow-band boost (+~34% drive, hues 32–95) breaks smooth gradients, the exact rescaling rule, which four effects opt in and why noise/texture effects deliberately keep the boost, and where the property is pinned on both sides. Also lists `FlattenedGradientRGB` among the `Effect` shared helpers.
- **docs/simulator.md**: suite count corrected to **eight** — d58a8a7 added the `gradientPower` suite but left the list saying "Seven suites".

## Verification (done on this branch pre-rebase, when it carried the full fix)

- RED proven independently by reverse-applying the fix: `GradientPowerTest` fails "Rainbow at time 0, LED 7 RGB (44,43,0) drive 87 exceeds allowed 68"; sim test fails identically
- `./ci.sh` green (90 smalltests + 14,400 fuzz, fatal ASan/UBSan); sim suite 61/61; corpus byte-identical to fresh `vectorgen` regen, diff scoped to effectIndex 0/9/13/33; `pio` node-arm64/fancy-node/controller build; clang-format + ESLint clean; adversarial verifier review (hand-checked integer math, JS parity, call sites, golden values)

This commit itself is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWLzz2Ew63qnvqFAJAnBx8