### PR TITLE
Pin forked FastLED version to full hash

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ platform_packages =
 ;	tool-bossac-candykingdom @ https://candykingdom.github.io/firefly-v2-board/tools/bossac_windows.tar.bz2
 lib_deps = 
 	mikem/RadioHead@^1.120
-	https://github.com/candykingdom/FastLED.git#12dee8f
+	https://github.com/candykingdom/FastLED.git#12dee8fe9d040dc6f32953e074058040255c8878
 	https://github.com/khoih-prog/FlashStorage_SAMD.git#v1.3.2
 
 [env:node-arm64]
@@ -34,7 +34,7 @@ extra_scripts = tools/create_uf2.py
 build_src_filter = +<devices/node> +<arduino> +<generic> -<*/test/*> -<*/build/*>
 lib_deps = 
 	mikem/RadioHead@^1.120
-	https://github.com/candykingdom/FastLED.git#12dee8f
+	https://github.com/candykingdom/FastLED.git#12dee8fe9d040dc6f32953e074058040255c8878
 	https://github.com/khoih-prog/FlashStorage_SAMD.git#v1.3.2
 upload_protocol = custom
 upload_command = ./bossac_wrapper.sh $UPLOAD_PORT "$BUILD_DIR/firmware.bin"


### PR DESCRIPTION
It appears something has recently changed in platformio which means that for pinning, a full hash needs to be used instead of a partial one.